### PR TITLE
improve Basic and Rectangle samples

### DIFF
--- a/Examples/Basic/basic.cpp
+++ b/Examples/Basic/basic.cpp
@@ -657,9 +657,9 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   // property handles and members of each image
   // in reality, we would put this in a struct as the C++ support layer does
   OfxPropertySetHandle sourceImg = NULL, outputImg = NULL, maskImg = NULL;
-  int srcRowBytes, srcBitDepth, dstRowBytes, dstBitDepth, maskRowBytes, maskBitDepth;
-  bool srcIsAlpha, dstIsAlpha, maskIsAlpha;
-  OfxRectI dstRect, srcRect, maskRect;
+  int srcRowBytes, srcBitDepth, dstRowBytes, dstBitDepth, maskRowBytes = 0, maskBitDepth;
+  bool srcIsAlpha, dstIsAlpha, maskIsAlpha = false;
+  OfxRectI dstRect, srcRect, maskRect = {0};
   void *src, *dst, *mask = NULL;
 
   try {
@@ -691,7 +691,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
     }
 
     // are we compenent scaling
-    bool scaleComponents;
+    int scaleComponents;
     gParamHost->paramGetValueAtTime(myData->perComponentScaleParam, time, &scaleComponents);
 
     // get the scale parameters

--- a/Examples/Rectangle/rectangle.cpp
+++ b/Examples/Rectangle/rectangle.cpp
@@ -619,10 +619,10 @@ static OfxStatus render(OfxImageEffectHandle effect,
   // property handles and members of each image
   // in reality, we would put this in a struct as the C++ support layer does
   OfxPropertySetHandle sourceImg = NULL, outputImg = NULL;
-  int srcRowBytes, srcBitDepth, dstRowBytes, dstBitDepth;
+  int srcRowBytes = 0, srcBitDepth, dstRowBytes, dstBitDepth;
   bool srcIsAlpha, dstIsAlpha;
-  OfxRectI dstRect, srcRect;
-  void *src, *dst;
+  OfxRectI dstRect, srcRect = {0};
+  void *src = NULL, *dst;
   
   // by default we are premultiplied
   bool unpremultiplied = false;


### PR DESCRIPTION
1. change Basic scaleComponents local from bool to int to fix stack
   trash in 64-bit builds.
2. initialize variables used in alternate code paths.
