### PR TITLE
fix various issues in ofx includes

### DIFF
--- a/include/ofxCore.h
+++ b/include/ofxCore.h
@@ -85,7 +85,7 @@ typedef struct OfxHost {
          - NULL if the API is unknown (either the api or the version requested),
 	 - pointer to the relevant API if it was found
   */
-  void *(*fetchSuite)(OfxPropertySetHandle host, const char *suiteName, int suiteVersion);
+  const void *(*fetchSuite)(OfxPropertySetHandle host, const char *suiteName, int suiteVersion);
 } OfxHost;
 
 
@@ -405,7 +405,7 @@ This is a longer version of the label, typically 32 character glyphs or so. Host
 /** @brief Indicates why a plug-in changed.
 
     - Type - ASCII C string X 1
-    - Property Set - the inArgs parameter on the ::kOfxActionInstanceChanged action.
+    - Property Set - inArgs parameter on the ::kOfxActionInstanceChanged action.
     - Valid Values - this can be...
        - ::kOfxChangeUserEdited - the user directly edited the instance somehow and caused a change to something, this includes undo/redos and resets
        - ::kOfxChangePluginEdited - the plug-in itself has changed the value of the object in some action
@@ -520,6 +520,9 @@ typedef struct OfxRectD {
 
 /** @brief String used to label unsigned 16 bit integer samples */
 #define kOfxBitDepthShort "OfxBitDepthShort"
+
+/** @brief String used to label the OpenGL half float (16 bit floating point) sample format */
+#define kOfxBitDepthHalf "OfxBitDepthHalf"
 
 /** @brief String used to label signed 32 bit floating point samples */
 #define kOfxBitDepthFloat "OfxBitDepthFloat"

--- a/include/ofxDialog.h
+++ b/include/ofxDialog.h
@@ -31,6 +31,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "ofxCore.h"
+#include "ofxProperty.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -478,6 +478,7 @@ On a clip, it indicates that the clip needs temporal access to images.
        - kOfxBitDepthNone (implying a clip is unconnected, not valid for an image)
        - kOfxBitDepthByte
        - kOfxBitDepthShort
+       - kOfxBitDepthHalf
        - kOfxBitDepthFloat
 
 Note that for a clip, this is the value set by the clip preferences action, not the raw 'actual' value of the clip.
@@ -532,6 +533,7 @@ errors the frame rate should then be set to 0.
        - kOfxBitDepthNone (implying a clip is unconnected image)
        - kOfxBitDepthByte
        - kOfxBitDepthShort
+       - kOfxBitDepthHalf
        - kOfxBitDepthFloat
 
 This is the actual value of the component depth, before any mapping by clip preferences.
@@ -582,6 +584,7 @@ See the documentation on clip preferences for more details on how this is used w
        - kOfxBitDepthNone (implying a clip is unconnected, not valid for an image)
        - kOfxBitDepthByte
        - kOfxBitDepthShort
+       - kOfxBitDepthHalf
        - kOfxBitDepthFloat
 
 The default for a plugin is to have none set, the plugin \em must define at least one in its describe action.
@@ -1003,6 +1006,9 @@ This will be in \ref PixelCoordinates
 /** @brief String that is the name of the 'from' clip in the OFX transition context */
 #define kOfxImageEffectTransitionSourceToClipName "SourceTo"
 
+/** @brief the name of the mandated 'Transition' param for the transition context */
+#define kOfxImageEffectTransitionParamName "Transition"
+
 /** @brief the name of the mandated 'SourceTime' param for the retime context */
 #define kOfxImageEffectRetimerParamName "SourceTime"
 
@@ -1141,7 +1147,7 @@ If clipGetImage is called twice with the same parameters, then two separate imag
   */
   OfxStatus (*clipGetImage)(OfxImageClipHandle clip,
 			    OfxTime       time,
-			    OfxRectD     *region,
+			    const OfxRectD     *region,
 			    OfxPropertySetHandle   *imageHandle);
   
   /** @brief Releases the image handle previously returned by clipGetImage

--- a/include/ofxMultiThread.h
+++ b/include/ofxMultiThread.h
@@ -135,7 +135,7 @@ typedef struct OfxMultiThreadSuiteV1 {
   @returns
   - kOfxStatOK - mutex is now valid and ready to go
   */
-  OfxStatus (*mutexCreate)(const OfxMutexHandle *mutex, int lockCount);
+  OfxStatus (*mutexCreate)(OfxMutexHandle *mutex, int lockCount);
 
   /** @brief Destroy a mutex
       

--- a/include/ofxOpenGLRender.h
+++ b/include/ofxOpenGLRender.h
@@ -272,8 +272,8 @@ returns
 
   OfxStatus (*clipLoadTexture)(OfxImageClipHandle clip,
                                OfxTime       time,
-			       const char   *format,
-                               OfxRectD     *region,
+                               const char   *format,
+                               const OfxRectD     *region,
                                OfxPropertySetHandle   *textureHandle);
 
   /** @brief Releases the texture handle previously returned by

--- a/include/ofxParam.h
+++ b/include/ofxParam.h
@@ -225,7 +225,7 @@ If set to anything other than 0.0, the custom interface for this parameter will 
 
 /** @brief The minimum size of a parameter's custom interface, in screen pixels.
 
-    - Type - int x 2
+    - Type - double x 2
     - Property Set - plugin parameter descriptor (read/write) and instance (read only)
     - Default - 10,10
     - Valid Values - greater than (0, 0)
@@ -704,7 +704,6 @@ If a user interface represents a parameter with a slider or similar, this should
 
     - Type - int or double X N
     - Property Set - plugin parameter descriptor (read/write) and instance (read/write),
-    - Default - the largest possible value corresponding to the parameter type (eg: INT_MIN for an integer, -DBL_MAX for a double parameter)
 
 If a user interface represents a parameter with a slider or similar, this should be the maximum bound on that slider.
 */
@@ -824,7 +823,6 @@ This property is on the \e inArgs property and \e outArgs property of a ::OfxCus
 /** @brief Used by interpolating custom parameters to indicate the time a key occurs at.
 
    - Type - double X 2
-   - Property Set - the inArgs parameter of a ::OfxCustomParamInterpFuncV1 (read only)
 
 The two values indicate the absolute times the surrounding keyframes occur at. The keyframes are encoded in a ::kOfxParamPropCustomValue property.
 
@@ -834,7 +832,6 @@ The two values indicate the absolute times the surrounding keyframes occur at. T
 /** @brief Property used by ::OfxCustomParamInterpFuncV1 to indicate the amount of interpolation to perform
 
    - Type - double X 1
-   - Property Set - the inArgs parameter of a ::OfxCustomParamInterpFuncV1 (read only)
    - Valid Values - from 0 to 1
 
 This property indicates how far between the two ::kOfxParamPropCustomValue keys to interpolate.
@@ -1202,7 +1199,6 @@ changes a keyframe.  The keyframe indices will not change within a single action
   - ::kOfxStatOK       - all was OK
   - ::kOfxStatErrBadHandle  - if the parameter handle was invalid
   */
-  OfxStatus (*paramCopy)(OfxParamHandle  paramTo, OfxParamHandle  paramFrom, OfxTime dstOffset, OfxRangeD *frameRange);
 
 
   /** @brief Used to group any parameter changes for undo/redo purposes

--- a/include/ofxParam.h
+++ b/include/ofxParam.h
@@ -704,6 +704,7 @@ If a user interface represents a parameter with a slider or similar, this should
 
     - Type - int or double X N
     - Property Set - plugin parameter descriptor (read/write) and instance (read/write),
+    - Default - the largest possible value corresponding to the parameter type (eg: INT_MAX for an integer, DBL_MAX for a double parameter)
 
 If a user interface represents a parameter with a slider or similar, this should be the maximum bound on that slider.
 */
@@ -774,6 +775,7 @@ It is an error not to set this property in a custom parameter during a plugin's 
         - ::kOfxParamStringIsFilePath
         - ::kOfxParamStringIsDirectoryPath
         - ::kOfxParamStringIsLabel
+        - ::kOfxParamStringIsRichTextFormat
 
 */
 #define kOfxParamPropStringMode "OfxParamPropStringMode"
@@ -823,6 +825,7 @@ This property is on the \e inArgs property and \e outArgs property of a ::OfxCus
 /** @brief Used by interpolating custom parameters to indicate the time a key occurs at.
 
    - Type - double X 2
+   - Property Set - inArgs parameter of a ::OfxCustomParamInterpFuncV1 (read only)
 
 The two values indicate the absolute times the surrounding keyframes occur at. The keyframes are encoded in a ::kOfxParamPropCustomValue property.
 
@@ -832,6 +835,7 @@ The two values indicate the absolute times the surrounding keyframes occur at. T
 /** @brief Property used by ::OfxCustomParamInterpFuncV1 to indicate the amount of interpolation to perform
 
    - Type - double X 1
+   - Property Set - inArgs parameter of a ::OfxCustomParamInterpFuncV1 (read only)
    - Valid Values - from 0 to 1
 
 This property indicates how far between the two ::kOfxParamPropCustomValue keys to interpolate.
@@ -1199,6 +1203,7 @@ changes a keyframe.  The keyframe indices will not change within a single action
   - ::kOfxStatOK       - all was OK
   - ::kOfxStatErrBadHandle  - if the parameter handle was invalid
   */
+  OfxStatus (*paramCopy)(OfxParamHandle  paramTo, OfxParamHandle  paramFrom, OfxTime dstOffset, const OfxRangeD *frameRange);
 
 
   /** @brief Used to group any parameter changes for undo/redo purposes

--- a/include/ofxPixels.h
+++ b/include/ofxPixels.h
@@ -78,7 +78,7 @@ typedef struct OfxRGBColourF {
 
 /** @brief Defines a double precision floating point component RGB pixel */
 typedef struct OfxRGBColourD {
-  double r, g, b, a;
+  double r, g, b;
 }OfxRGBColourD;
 
 #ifdef __cplusplus

--- a/include/ofxProperty.h
+++ b/include/ofxProperty.h
@@ -125,7 +125,7 @@ typedef struct OfxPropertySuiteV1 {
         - ::kOfxStatErrBadIndex
         - ::kOfxStatErrValue
  */
-  OfxStatus (*propSetPointerN)(OfxPropertySetHandle properties, const char *property, int count, void **value);
+  OfxStatus (*propSetPointerN)(OfxPropertySetHandle properties, const char *property, int count, void *const*value);
 
   /** @brief Set multiple values of a string property
 
@@ -141,7 +141,7 @@ typedef struct OfxPropertySuiteV1 {
         - ::kOfxStatErrBadIndex
         - ::kOfxStatErrValue
   */
-  OfxStatus (*propSetStringN) (OfxPropertySetHandle properties, const char *property, int count, const char **value);
+  OfxStatus (*propSetStringN) (OfxPropertySetHandle properties, const char *property, int count, const char *const*value);
 
   /** @brief Set multiple values of  a double property
 
@@ -158,7 +158,7 @@ typedef struct OfxPropertySuiteV1 {
         - ::kOfxStatErrValue
 
   */
-  OfxStatus (*propSetDoubleN) (OfxPropertySetHandle properties, const char *property, int count, double *value);
+  OfxStatus (*propSetDoubleN) (OfxPropertySetHandle properties, const char *property, int count, const double *value);
 
   /** @brief Set multiple values of an int property 
 
@@ -175,7 +175,7 @@ typedef struct OfxPropertySuiteV1 {
         - ::kOfxStatErrValue
 
  */
-  OfxStatus (*propSetIntN)    (OfxPropertySetHandle properties, const char *property, int count, int *value);
+  OfxStatus (*propSetIntN)    (OfxPropertySetHandle properties, const char *property, int count, const int *value);
   
   /** @brief Get a single value from a pointer property
 


### PR DESCRIPTION
- constify parameters and return values when appropriate
- add half sample format (required for OpenGL)
- kOfxParamPropInteractMinimumSize is a double x 2 in Nuke