### PR TITLE
Clip Property kOfxImageClipPropDisplayTimeOffset

### DIFF
--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -935,7 +935,8 @@ then the plugin can detect this via an identifier change and re-evaluate the cac
    - Property Set -  clip instance (read only)
    - Default - 0
 
-This value should be added to the internal frame number when displayed in a plugin user interface
+Plugins should add this value to internal OFX frame numbers when displayed in a plugin user interface, so the user will see the
+same frame numbers as they see in the host's UI.
 */
 #define kOfxImageClipPropDisplayTimeOffset "kOfxImageClipPropDisplayTimeOffset"
 

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -929,6 +929,16 @@ then the plugin can detect this via an identifier change and re-evaluate the cac
 */
 #define kOfxImagePropUniqueIdentifier "OfxImagePropUniqueIdentifier"
 
+/** @brief Clip property which indicates the display start frame of the clip
+
+   - Type - double X 1
+   - Property Set -  clip instance (read only)
+   - Default - 0
+
+This value should be added to the internal frame number when displayed in a plugin user interface
+*/
+#define kOfxImageClipPropDisplayTimeOffset "kOfxImageClipPropDisplayTimeOffset"
+
 /** @brief Clip and action argument property which indicates that the clip can be sampled continously
 
    - Type - int X 1


### PR DESCRIPTION
Issue #58 
I added a #define and description for kOfxImageClipPropDisplayTimeOffset.
A plugin can query this read-only clip property to determine the clip starting frame number in the environment's user time domain. ie if the clip starts at frame 1001, this property would return 1001. This value should be added to time values for purposes of display in a custom user interface that shows frame numbers (ie. a special preset browser or custom player).
