### PR TITLE
Update ofxsProcessing.H

### DIFF
--- a/Support/Plugins/include/ofxsProcessing.H
+++ b/Support/Plugins/include/ofxsProcessing.H
@@ -134,10 +134,10 @@ namespace OFX {
             preProcess();
 
             // make sure there are at least 4096 pixels per CPU and at least 1 line par CPU
-            unsigned int nCPUs = (std::min(_renderWindow.x2 - _renderWindow.x1, 4096) *
+            unsigned int nCPUs = ((std::min)(_renderWindow.x2 - _renderWindow.x1, 4096) *
                                   (_renderWindow.y2 - _renderWindow.y1)) / 4096;
             // make sure the number of CPUs is valid (and use at least 1 CPU)
-            nCPUs = std::max(1u, std::min(nCPUs, OFX::MultiThread::getNumCPUs()));
+            nCPUs = (std::max)(1u, (std::min)(nCPUs, OFX::MultiThread::getNumCPUs()));
 
             // call the base multi threading code, should put a pre & post thread calls in too
             multiThread(nCPUs);


### PR DESCRIPTION
Bypass macro due to compiler errors thrown:

'(' : illegal token on right side of '::'