### PR TITLE
Fix CI build problems: conan_version, expat, compiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,8 @@ jobs:
             need_node20_vol: true
             has_cmake_presets: false
             buildtype: Release
-            conan_version: 2.1.0
+            # use old conan version for CentOS 7
+            conan_version: 2.10.3
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang
@@ -58,7 +59,8 @@ jobs:
             need_node20_vol: true
             has_cmake_presets: false
             buildtype: Release
-            conan_version: 2.1.0
+            # use old conan version for CentOS 7
+            conan_version: 2.10.3
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang
@@ -74,7 +76,7 @@ jobs:
             vfx-cy: 2023
             has_cmake_presets: false
             buildtype: Release
-            conan_version: 2.1.0
+            conan_version: 2.20.1
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang
@@ -90,7 +92,7 @@ jobs:
             vfx-cy: 2023
             has_cmake_presets: false
             buildtype: Release
-            conan_version: 2.1.0
+            conan_version: 2.20.1
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang
@@ -103,7 +105,7 @@ jobs:
             os: ubuntu-latest
             has_cmake_presets: true
             buildtype: Release
-            conan_version: 2.1.0
+            conan_version: 2.20.1
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang
@@ -116,7 +118,7 @@ jobs:
             os: macos-latest
             has_cmake_presets: true
             buildtype: Release
-            conan_version: 2.1.0
+            conan_version: 2.20.1
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang
@@ -129,7 +131,7 @@ jobs:
             os: windows-latest
             has_cmake_presets: true
             buildtype: Release
-            conan_version: 2.1.0
+            conan_version: 2.20.1
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang
@@ -142,7 +144,7 @@ jobs:
             os: windows-latest
             has_cmake_presets: true
             buildtype: Release
-            conan_version: 2.0.16
+            conan_version: 2.20.1
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang

--- a/conanfile.py
+++ b/conanfile.py
@@ -39,7 +39,7 @@ class openfx(ConanFile):
 			self.requires("opencl-icd-loader/2023.12.14")
 			self.requires("opencl-headers/2023.12.14")
 		self.requires("opengl/system") # for OpenGL examples
-		self.requires("expat/2.4.8") # for HostSupport
+		self.requires("expat/2.7.1") # for HostSupport
 		self.requires("cimg/3.3.2") # to draw text into images
 		self.requires("spdlog/1.13.0") # for logging
 


### PR DESCRIPTION
- Bump expat to 2.7.1 because old version doesn't build on MacOS anymore
- Bump conan version to 2.20.1 to support latest dependencies (e.g. expat), except where it doesn't work, e.g. CentOS 7. This also fixes the MacOS build which is now up to compiler version 17, and the old conan would reject that.
- Add support for `uvx conan` for python uv users

Also note: I had to remove the very old `import` and `IMPORT` git tags recently because they cause trouble with git on Windows (case-insensitive filesystem I think). Not included in this commit, but needed to fix the CI build.