### PR TITLE
Feature/conform

### DIFF
--- a/include/ofxCore.h
+++ b/include/ofxCore.h
@@ -669,6 +669,15 @@ This property is used to label objects uniquely amoung objects of that type. It 
 */
 #define kOfxPropName "OfxPropName"
 
+/** @brief Alternative names for an object.
+
+    - Type - string X N
+    - Property Set - on many objects (descriptors and instances), see \ref PropertiesByObject (read only)
+
+This property is used to provide alternative names for objects. It can be used in any situation where ::kOfxPropName is used, and is helpful for situations where the effects are being transferred from another plug-in API.
+*/
+#define kOfxPropAka "OfxPropAka"
+
 /** @brief Identifies a specific version of a host or plugin.
 
     - Type - int X N

--- a/include/ofxCore.h
+++ b/include/ofxCore.h
@@ -705,6 +705,15 @@ This property is used to provide alternative names for objects. It can be used i
 */
 #define kOfxPropAka "OfxPropAka"
 
+/** @brief Alternative names for parameter dimensions.
+
+    - Type - string X N X M
+    - Property Set - multidimensional parameter descriptors, see \ref PropertiesByObject (read only)
+
+This property is used to provide alternative names for each dimension of a multidimensional parameter. It can be used in situations where effects are being transferred from another plug-in API that doesn't support multidimensional parameters, and each dimension was stored as a separate parameter.
+*/
+#define kOfxPropAka2D "OfxPropAka2D"
+
 /** @brief Identifies a specific version of a host or plugin.
 
     - Type - int X N

--- a/include/ofxCore.h
+++ b/include/ofxCore.h
@@ -548,6 +548,33 @@ These are the actions passed to a plug-in's 'main' function
  */
 #define kOfxActionEndInstanceEdit "OfxActionEndInstanceEdit"
 
+/** @brief
+
+ This is called when the effect has been imported from another host. It
+ is there so that effects can conform their parameters, accounting for
+ differences in parameter semantics between hosts. Plug-ins should use
+ \ref kOfxPropAka to inform hosts if their parameters have different names
+ in other APIs.
+
+ @param  handle handle to the plug-in instance, cast to an \ref OfxImageEffectHandle
+ @param  inArgs is redundant and is set to NULL
+ @param  outArgs is redundant and is set to NULL
+
+ \pre
+     -  \ref kOfxActionCreateInstance has been called on the instance handle.
+
+ \post
+     -  the instance will match the source host as closely as possible.
+
+ @returns
+     -  \ref kOfxStatOK, the action was trapped and all was well
+     -  \ref kOfxStatReplyDefault, the action was ignored
+     -  \ref kOfxStatErrFatal,
+     -  \ref kOfxStatFailed, something went wrong, but no error code appropriate,
+     the plugin should to post a message
+ */
+#define kOfxActionConform "OfxActionConform"
+
 /*@}*/
 
 /** @brief Returns the 'nth' plug-in implemented inside a binary

--- a/include/ofxCore.h
+++ b/include/ofxCore.h
@@ -707,12 +707,15 @@ This property is used to provide alternative names for objects. It can be used i
 
 /** @brief Alternative names for parameter dimensions.
 
-    - Type - string X N X M
+    - Type - string X N
     - Property Set - multidimensional parameter descriptors, see \ref PropertiesByObject (read only)
 
-This property is used to provide alternative names for each dimension of a multidimensional parameter. It can be used in situations where effects are being transferred from another plug-in API that doesn't support multidimensional parameters, and each dimension was stored as a separate parameter.
+These properties are used to provide alternative names for each dimension of a multidimensional parameter, e.g. OfxParamTypeRGBA. They can be used in situations where effects are being transferred from another plug-in API that doesn't support multidimensional parameters, and each dimension was stored as a separate parameter. Four properties are defined as that is the maximum number of dimensions on any standard parameter type. If parameter types are defined with more dimensions, they can be assumed to follow the same pattern.
 */
-#define kOfxPropAka2D "OfxPropAka2D"
+#define kOfxPropAka0 "OfxPropAka0"
+#define kOfxPropAka1 "OfxPropAka1"
+#define kOfxPropAka2 "OfxPropAka2"
+#define kOfxPropAka3 "OfxPropAka3"
 
 /** @brief Identifies a specific version of a host or plugin.
 


### PR DESCRIPTION
This change adds new properties and an action to help hosts with editorial timeline conform, as described in #217.

`kOfxPropAka` will allow plug-ins to list alternative names by which any named object could be known. A `kOfxPropAka2D` property covers multidimensional parameters. For example, an effect could list the name it is known by in a different API such as AVX or Adobe. It can also list the names its parameters are known by, which might be GUIDs or similar.

The conform action, `kOfxActionConform`, will allow plug-ins to update their parameter values and keyframes based on information passed from the host. Prior to invoking this action, hosts will set parameter values to the best of their ability, and the plug-in will examine these and update them based on internal knowledge about where they came from. For example, a spatial parameter might need to be adjusted to compensate for different origin.