### PR TITLE
Add #ifndef guard for NOMINMAX macro define

### DIFF
--- a/HostSupport/include/ofxhBinary.h
+++ b/HostSupport/include/ofxhBinary.h
@@ -26,7 +26,9 @@
 #if defined(UNIX)
 #include <dlfcn.h>
 #elif defined (_WIN32)
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include "windows.h"
 #include <assert.h>
 #endif


### PR DESCRIPTION
Down the line some projects consuming openfx source code defines there own `NOMINMAX` define via command line.

This result in few warnings like:
```
warning C4005: 'NOMINMAX': macro redefinition
```

This MR fixes that.