### PR TITLE
Fix issue #236: drop FMT_STRING wrappers in ColourSpace example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,27 @@ jobs:
             compiler-desc: Clang
             cuda: false
             opencl: true
+          - name_prefix: Linux Rocky 8 VFX CY2023 strict fmt
+            # Regression guard for openfx#236 / #237: ensures every
+            # fmt/spdlog callsite with format args uses OFX_FMT_STRING.
+            # Intentionally does not produce release artifacts.
+            release_prefix: linux-vfx2023-strict-fmt
+            ostype: linux
+            aswfdockerbuild: true
+            os: ubuntu-latest
+            container: aswf/ci-base:2023
+            vfx-cy: 2023
+            has_cmake_presets: false
+            buildtype: Release
+            conan_version: 2.20.1
+            cxx-standard: 17
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang
+            cuda: false
+            opencl: true
+            extra_cmake_cxx_flags: -DFMT_ENFORCE_COMPILE_STRING
+            skip_release_upload: true
           - name_prefix: Linux Rocky 8 VFX CY2023 No OpenGL
             release_prefix: linux-vfx2023-no-ogl
             ostype: linux
@@ -321,6 +342,7 @@ jobs:
           MATRIX_CUDA: ${{ matrix.cuda }}
           MATRIX_HAS_PRESETS: ${{ matrix.has_cmake_presets }}
           MATRIX_OSTYPE: ${{ matrix.ostype }}
+          MATRIX_EXTRA_CXX_FLAGS: ${{ matrix.extra_cmake_cxx_flags }}
         run: |
           CMAKE_DEFINES=(-DBUILD_EXAMPLE_PLUGINS=TRUE \
               -DPLUGIN_INSTALLDIR=$(pwd)/build/Install)
@@ -331,6 +353,9 @@ jobs:
              [[ "$MATRIX_CUDA"   = true ]] && CMAKE_DEFINES+=(-DOFX_SUPPORTS_CUDARENDER=TRUE)
           else
              echo "OPENGL_BUILD=-no-ogl" >> $GITHUB_ENV
+          fi
+          if [[ -n "$MATRIX_EXTRA_CXX_FLAGS" ]]; then
+             CMAKE_DEFINES+=(-DCMAKE_CXX_FLAGS="$MATRIX_EXTRA_CXX_FLAGS")
           fi
           CMAKE_GENERATOR=(-G Ninja)
           if [[ $MATRIX_HAS_PRESETS = true ]]; then
@@ -384,6 +409,7 @@ jobs:
 
 
       - name: Copy includes and libs into release folder for installation
+        if: matrix.skip_release_upload != true
         # Dir structure:
         #  Install/OpenFX
         #   lib
@@ -422,12 +448,13 @@ jobs:
 
       # Create and sign headers/libs tarball
       - name: Create headers/libs tarball
+        if: matrix.skip_release_upload != true
         run: |
           tar -czf openfx-$RELEASE_NAME.tar.gz -C Install OpenFX
 
       # Install and run sigstore manually for CentOS 7 (sigstore action doesn't work with uv Python)
       - name: Install sigstore manually (CentOS 7)
-        if: github.event_name == 'release' && (matrix.vfx-cy == 2021 || matrix.vfx-cy == 2022)
+        if: github.event_name == 'release' && matrix.skip_release_upload != true && (matrix.vfx-cy == 2021 || matrix.vfx-cy == 2022)
         run: |
           # Conan installed urllib3 1.26.x, but tuf (required by sigstore) needs urllib3 2.x for BaseHTTPResponse
           # Explicitly upgrade urllib3 first, then install sigstore
@@ -435,14 +462,14 @@ jobs:
           python3.11 -m pip install --user 'sigstore>=3,<4'
 
       - name: Sign header/libs tarball with Sigstore manually (CentOS 7)
-        if: github.event_name == 'release' && (matrix.vfx-cy == 2021 || matrix.vfx-cy == 2022)
+        if: github.event_name == 'release' && matrix.skip_release_upload != true && (matrix.vfx-cy == 2021 || matrix.vfx-cy == 2022)
         run: |
           # uv Python needs SSL_CERT_FILE to use certifi's CA bundle instead of outdated system certs
           export SSL_CERT_FILE=$(python3.11 -c "import certifi; print(certifi.where())")
           python3.11 -m sigstore sign openfx-${{ env.RELEASE_NAME }}.tar.gz
 
       - name: Sign header/libs tarball with Sigstore (action for other platforms)
-        if: github.event_name == 'release' && matrix.vfx-cy != 2021 && matrix.vfx-cy != 2022
+        if: github.event_name == 'release' && matrix.skip_release_upload != true && matrix.vfx-cy != 2021 && matrix.vfx-cy != 2022
         uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
         with:
           inputs: openfx-${{ env.RELEASE_NAME }}.tar.gz
@@ -450,7 +477,7 @@ jobs:
           release-signing-artifacts: false
 
       - name: Upload header/libs tarball and signatures
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && matrix.skip_release_upload != true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "openfx-${{ env.RELEASE_NAME }}"
@@ -459,7 +486,7 @@ jobs:
             openfx-${{ env.RELEASE_NAME }}.tar.gz.sigstore.json
 
       - name: Upload header/libs tarball (no signatures)
-        if: github.event_name != 'release'
+        if: github.event_name != 'release' && matrix.skip_release_upload != true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "openfx-${{ env.RELEASE_NAME }}"
@@ -469,19 +496,20 @@ jobs:
       # Now the same, for the plugins
 
       - name: Create built/installed plugins tarball
+        if: matrix.skip_release_upload != true
         run: |
           tar -czf openfx_plugins-$RELEASE_NAME.tar.gz -C build/Install .
 
       # Sign plugins manually for CentOS 7 (sigstore already installed above)
       - name: Sign plugins tarball with Sigstore manually (CentOS 7)
-        if: github.event_name == 'release' && (matrix.vfx-cy == 2021 || matrix.vfx-cy == 2022)
+        if: github.event_name == 'release' && matrix.skip_release_upload != true && (matrix.vfx-cy == 2021 || matrix.vfx-cy == 2022)
         run: |
           # uv Python needs SSL_CERT_FILE to use certifi's CA bundle instead of outdated system certs
           export SSL_CERT_FILE=$(python3.11 -c "import certifi; print(certifi.where())")
           python3.11 -m sigstore sign openfx_plugins-${{ env.RELEASE_NAME }}.tar.gz
 
       - name: Sign plugins tarball with Sigstore (action for other platforms)
-        if: github.event_name == 'release' && matrix.vfx-cy != 2021 && matrix.vfx-cy != 2022
+        if: github.event_name == 'release' && matrix.skip_release_upload != true && matrix.vfx-cy != 2021 && matrix.vfx-cy != 2022
         uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
         with:
           inputs: openfx_plugins-${{ env.RELEASE_NAME }}.tar.gz
@@ -489,7 +517,7 @@ jobs:
           release-signing-artifacts: false
 
       - name: Upload plugins tarball and signatures
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && matrix.skip_release_upload != true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "openfx_plugins-${{ env.RELEASE_NAME }}"
@@ -498,7 +526,7 @@ jobs:
             openfx_plugins-${{ env.RELEASE_NAME }}.tar.gz.sigstore.json
 
       - name: Upload plugins tarball (no signatures)
-        if: github.event_name != 'release'
+        if: github.event_name != 'release' && matrix.skip_release_upload != true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "openfx_plugins-${{ env.RELEASE_NAME }}"
@@ -506,7 +534,7 @@ jobs:
             openfx_plugins-${{ env.RELEASE_NAME }}.tar.gz
 
       - name: Upload artifacts to release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && matrix.skip_release_upload != true
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}

--- a/Examples/ColourSpace/Makefile
+++ b/Examples/ColourSpace/Makefile
@@ -1,0 +1,10 @@
+PLUGINOBJECTS = colourspace.o
+PLUGINNAME = colourspace
+PATHTOROOT = ../
+
+# ColourSpace needs spdlog, fmt (via spdlog), and CImg headers.
+# Pass their locations via CXXFLAGS_ADD on the make command line, e.g.:
+#   make CXXFLAGS_ADD="-I/path/to/spdlog/include -I/path/to/CImg"
+# Add -DSPDLOG_FMT_EXTERNAL -I/path/to/fmt/include if using an external fmt.
+
+include ../Makefile.master

--- a/Examples/ColourSpace/colourspace.cpp
+++ b/Examples/ColourSpace/colourspace.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <array>
 #include <cstring>
-#include "spdlog/spdlog.h"
+#include "../include/ofxSpdlogCompat.h"
 #define cimg_display 0          // no X11
 #include "CImg.h"
 #include "ofxImageEffect.h"
@@ -58,7 +58,7 @@ ColourManagementStyle ofxstring_to_style(const std::string & style)
   else if(style == kOfxImageEffectColourManagementOCIO)
     return ColourManagementStyle::OCIO;
   else {
-    spdlog::info("unknown colour management style '{}'", style);
+    spdlog::info(OFX_FMT_STRING("unknown colour management style '{}'"), style);
     return ColourManagementStyle::None;
   }
 }
@@ -580,7 +580,7 @@ getClipPreferences( OfxImageEffectHandle effect, OfxPropertySetHandle /*inArgs*/
 	fallbackInputSpace ? fallbackInputSpace : kOfxColourspaceRoleSceneLinear,
 	kOfxColourspaceRoleSceneLinear};
       for (size_t i = 0; i < std::size(colourSpaces); i++) {
-	spdlog::info("Specifying preferred input colourspace #{} = {}", i+1, colourSpaces[i]);
+	spdlog::info(OFX_FMT_STRING("Specifying preferred input colourspace #{} = {}"), i+1, colourSpaces[i]);
 	gPropHost->propSetString(outArgs, kOfxImageClipPropPreferredColourspaces "_Source",
 				 i, colourSpaces[i]);
       }
@@ -626,7 +626,7 @@ getOutputColourspace( OfxImageEffectHandle  effect,  OfxPropertySetHandle /*inAr
     if (outputSpace == NULL || outputSpace[0] == '\0') {
       spdlog::info("Not specifying an output colourspace");
     } else {
-      spdlog::info("Specifying output colourspaces = {}", outputSpace);
+      spdlog::info(OFX_FMT_STRING("Specifying output colourspaces = {}"), outputSpace);
       // Set the selected colourspace in outArgs
       gPropHost->propSetString(outArgs, kOfxImageClipPropColourspace, 0, outputSpace);
       status = kOfxStatOK;
@@ -687,7 +687,7 @@ static std::string getClipColourspace(const OfxImageClipHandle clip) {
     if (status == kOfxStatOK) {
       return std::string(tmpStr);
     } else {
-      spdlog::info("Can't get clip's colourspace; propGetString returned {}", errMsg(status));
+      spdlog::info(OFX_FMT_STRING("Can't get clip's colourspace; propGetString returned {}"), errMsg(status));
       return std::string("unspecified");
     }
 
@@ -709,7 +709,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   OfxStatus st = gPropHost->propGetDoubleN(inArgs, kOfxImageEffectPropRenderScale, 2,
                                           renderScale);
   if (st != kOfxStatOK) {
-    spdlog::warn("Can't get render scale! {}", errMsg(st));
+    spdlog::warn(OFX_FMT_STRING("Can't get render scale! {}"), errMsg(st));
     renderScale[0] = renderScale[1] = 1.0f;
   }
   // retrieve any instance data associated with this effect
@@ -724,9 +724,9 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   void *src, *dst;
 
   std::string inputColourspace = getClipColourspace(myData->sourceClip);
-  spdlog::info("source clip colourspace = {}", inputColourspace);
+  spdlog::info(OFX_FMT_STRING("source clip colourspace = {}"), inputColourspace);
   std::string outputColourspace = getClipColourspace(myData->outputClip);
-  spdlog::info("output clip colourspace = {}", outputColourspace);
+  spdlog::info(OFX_FMT_STRING("output clip colourspace = {}"), outputColourspace);
 
   // In a real plugin, the render behaviour will change based on the
   // input and output colourspaces set in the clips.
@@ -762,7 +762,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
 
     int nchannels = 4;
     int font_height = 50 * renderScale[0];
-    spdlog::info("Rendering {}x{} image @{},{}, depth={}", xdim, ydim, srcRect.x1, srcRect.y1, dstBitDepth);
+    spdlog::info(OFX_FMT_STRING("Rendering {}x{} image @{},{}, depth={}"), xdim, ydim, srcRect.x1, srcRect.y1, dstBitDepth);
 
     // Just copy from source to dest, and draw some text
     if (srcRowBytes < 0 && dstRowBytes < 0)
@@ -770,13 +770,13 @@ static OfxStatus render( OfxImageEffectHandle  instance,
     else
       memcpy(dst, src, srcRowBytes * ydim);
     int ystart = ydim - 100;
-    drawText(fmt::format("Image: {}x{}, depth={}, scale={:.2f}x{:.2f}", xdim, ydim, dstBitDepth, renderScale[0], renderScale[1]),
+    drawText(fmt::format(OFX_FMT_STRING("Image: {}x{}, depth={}, scale={:.2f}x{:.2f}"), xdim, ydim, dstBitDepth, renderScale[0], renderScale[1]),
              100, ystart, font_height, dst, xdim, ydim, dstBitDepth, nchannels, dstRowBytes);
     ystart -= font_height;
-    drawText(fmt::format("input colourspace: {}", inputColourspace),
+    drawText(fmt::format(OFX_FMT_STRING("input colourspace: {}"), inputColourspace),
 	     100, ystart, font_height, dst, xdim, ydim, dstBitDepth, nchannels, dstRowBytes);
     ystart -= font_height;
-    drawText(fmt::format("output colourspace: {}", outputColourspace),
+    drawText(fmt::format(OFX_FMT_STRING("output colourspace: {}"), outputColourspace),
              100, ystart, font_height, dst, xdim, ydim, dstBitDepth, nchannels, dstRowBytes);
   }
   catch(OfxuNoImageException &ex) {
@@ -911,7 +911,7 @@ describe(OfxImageEffectHandle  effect)
   if (stat == kOfxStatOK) {
     gHostColourManagementStyle = ofxstring_to_style(tmpStr);
   } else {
-    spdlog::info("describe: host does not support colour management (err={})", errMsg(stat));
+    spdlog::info(OFX_FMT_STRING("describe: host does not support colour management (err={})"), errMsg(stat));
     gHostColourManagementStyle = ColourManagementStyle::None;
   }
 
@@ -971,7 +971,7 @@ describe(OfxImageEffectHandle  effect)
       break;
     }
     if (stat != kOfxStatOK) {
-      spdlog::error("setting kOfxImageEffectPropColourManagementStyle prop: stat={}", errMsg(stat));
+      spdlog::error(OFX_FMT_STRING("setting kOfxImageEffectPropColourManagementStyle prop: stat={}"), errMsg(stat));
     }
   }
 
@@ -991,7 +991,7 @@ pluginMain(const char *action, const void *handle, OfxPropertySetHandle inArgs, 
   OfxStatus stat = kOfxStatOK;
 
   if (silentActions.find(action) == silentActions.end())
-    spdlog::info(">>> pluginMain({})", action);
+    spdlog::info(OFX_FMT_STRING(">>> pluginMain({})"), action);
   try {
   // cast to appropriate type
   OfxImageEffectHandle effect = (OfxImageEffectHandle) handle;
@@ -1044,10 +1044,10 @@ pluginMain(const char *action, const void *handle, OfxPropertySetHandle inArgs, 
     stat = kOfxStatErrMemory;
   } catch ( const std::exception& e ) {
     // standard exceptions
-    spdlog::error("Caught OFX Plugin error {}", e.what());
+    spdlog::error(OFX_FMT_STRING("Caught OFX Plugin error {}"), e.what());
     stat = kOfxStatErrUnknown;
   } catch (int err) {
-    spdlog::error("Caught misc error {}", err);
+    spdlog::error(OFX_FMT_STRING("Caught misc error {}"), err);
     stat = err;
   } catch ( ... ) {
     // everything else
@@ -1058,7 +1058,7 @@ pluginMain(const char *action, const void *handle, OfxPropertySetHandle inArgs, 
 
 
   if (silentActions.find(action) == silentActions.end())
-    spdlog::info("<<< pluginMain({}) = {}", action, errMsg(stat));
+    spdlog::info(OFX_FMT_STRING("<<< pluginMain({}) = {}"), action, errMsg(stat));
   return stat;
 }
 

--- a/Examples/ColourSpace/colourspace.cpp
+++ b/Examples/ColourSpace/colourspace.cpp
@@ -32,11 +32,6 @@
 #  error Not building on your operating system quite yet
 #endif
 
-// In some environments {fmt} needs FMT_STRING
-#ifndef FMT_STRING
-#define FMT_STRING(x) x
-#endif
-
 enum class ColourManagementStyle
 {
   None, Basic, Core, Full, OCIO
@@ -63,7 +58,7 @@ ColourManagementStyle ofxstring_to_style(const std::string & style)
   else if(style == kOfxImageEffectColourManagementOCIO)
     return ColourManagementStyle::OCIO;
   else {
-    spdlog::info(FMT_STRING("unknown colour management style '{}'"), style);
+    spdlog::info("unknown colour management style '{}'", style);
     return ColourManagementStyle::None;
   }
 }
@@ -576,22 +571,22 @@ getClipPreferences( OfxImageEffectHandle effect, OfxPropertySetHandle /*inArgs*/
 
   // Colour management -- preferred colourspaces, in order (most preferred first)
   if (active_style != ColourManagementStyle::None) {
-    spdlog::info(FMT_STRING("Specifying preferred input colourspaces"));
+    spdlog::info("Specifying preferred input colourspaces");
     if(preferredInputSpace == NULL) {
-      spdlog::info(FMT_STRING("Not specifying any preference"));
+      spdlog::info("Not specifying any preference");
     } else {
       const char* colourSpaces[] = {
 	preferredInputSpace, // this is the user's choice
 	fallbackInputSpace ? fallbackInputSpace : kOfxColourspaceRoleSceneLinear,
 	kOfxColourspaceRoleSceneLinear};
       for (size_t i = 0; i < std::size(colourSpaces); i++) {
-	spdlog::info(FMT_STRING("Specifying preferred input colourspace #{} = {}"), i+1, colourSpaces[i]);
+	spdlog::info("Specifying preferred input colourspace #{} = {}", i+1, colourSpaces[i]);
 	gPropHost->propSetString(outArgs, kOfxImageClipPropPreferredColourspaces "_Source",
 				 i, colourSpaces[i]);
       }
     }
   } else {
-    spdlog::info(FMT_STRING("Host does not support colour management (this example won't be very interesting)"));
+    spdlog::info("Host does not support colour management (this example won't be very interesting)");
   }
 
   return kOfxStatOK;
@@ -629,15 +624,15 @@ getOutputColourspace( OfxImageEffectHandle  effect,  OfxPropertySetHandle /*inAr
     gParamHost->paramGetValue(myData->outputSpaceParam, &outputSpace);
   
     if (outputSpace == NULL || outputSpace[0] == '\0') {
-      spdlog::info(FMT_STRING("Not specifying an output colourspace"));
+      spdlog::info("Not specifying an output colourspace");
     } else {
-      spdlog::info(FMT_STRING("Specifying output colourspaces = {}"), outputSpace);
+      spdlog::info("Specifying output colourspaces = {}", outputSpace);
       // Set the selected colourspace in outArgs
       gPropHost->propSetString(outArgs, kOfxImageClipPropColourspace, 0, outputSpace);
       status = kOfxStatOK;
     }
   } else {
-    spdlog::info(FMT_STRING("Host does not support colour management (this example won't be very interesting)"));
+    spdlog::info("Host does not support colour management (this example won't be very interesting)");
     status = kOfxStatFailed;
   }
    
@@ -692,7 +687,7 @@ static std::string getClipColourspace(const OfxImageClipHandle clip) {
     if (status == kOfxStatOK) {
       return std::string(tmpStr);
     } else {
-      spdlog::info(FMT_STRING("Can't get clip's colourspace; propGetString returned {}"), errMsg(status));
+      spdlog::info("Can't get clip's colourspace; propGetString returned {}", errMsg(status));
       return std::string("unspecified");
     }
 
@@ -714,7 +709,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   OfxStatus st = gPropHost->propGetDoubleN(inArgs, kOfxImageEffectPropRenderScale, 2,
                                           renderScale);
   if (st != kOfxStatOK) {
-    spdlog::warn(FMT_STRING("Can't get render scale! {}"), errMsg(st));
+    spdlog::warn("Can't get render scale! {}", errMsg(st));
     renderScale[0] = renderScale[1] = 1.0f;
   }
   // retrieve any instance data associated with this effect
@@ -729,9 +724,9 @@ static OfxStatus render( OfxImageEffectHandle  instance,
   void *src, *dst;
 
   std::string inputColourspace = getClipColourspace(myData->sourceClip);
-  spdlog::info(FMT_STRING("source clip colourspace = {}"), inputColourspace);
+  spdlog::info("source clip colourspace = {}", inputColourspace);
   std::string outputColourspace = getClipColourspace(myData->outputClip);
-  spdlog::info(FMT_STRING("output clip colourspace = {}"), outputColourspace);
+  spdlog::info("output clip colourspace = {}", outputColourspace);
 
   // In a real plugin, the render behaviour will change based on the
   // input and output colourspaces set in the clips.
@@ -767,7 +762,7 @@ static OfxStatus render( OfxImageEffectHandle  instance,
 
     int nchannels = 4;
     int font_height = 50 * renderScale[0];
-    spdlog::info(FMT_STRING("Rendering {}x{} image @{},{}, depth={}"), xdim, ydim, srcRect.x1, srcRect.y1, dstBitDepth);
+    spdlog::info("Rendering {}x{} image @{},{}, depth={}", xdim, ydim, srcRect.x1, srcRect.y1, dstBitDepth);
 
     // Just copy from source to dest, and draw some text
     if (srcRowBytes < 0 && dstRowBytes < 0)
@@ -775,13 +770,13 @@ static OfxStatus render( OfxImageEffectHandle  instance,
     else
       memcpy(dst, src, srcRowBytes * ydim);
     int ystart = ydim - 100;
-    drawText(fmt::format(FMT_STRING("Image: {}x{}, depth={}, scale={:.2f}x{:.2f}"), xdim, ydim, dstBitDepth, renderScale[0], renderScale[1]),
+    drawText(fmt::format("Image: {}x{}, depth={}, scale={:.2f}x{:.2f}", xdim, ydim, dstBitDepth, renderScale[0], renderScale[1]),
              100, ystart, font_height, dst, xdim, ydim, dstBitDepth, nchannels, dstRowBytes);
     ystart -= font_height;
-    drawText(fmt::format(FMT_STRING("input colourspace: {}"), inputColourspace),
+    drawText(fmt::format("input colourspace: {}", inputColourspace),
 	     100, ystart, font_height, dst, xdim, ydim, dstBitDepth, nchannels, dstRowBytes);
     ystart -= font_height;
-    drawText(fmt::format(FMT_STRING("output colourspace: {}"), outputColourspace),
+    drawText(fmt::format("output colourspace: {}", outputColourspace),
              100, ystart, font_height, dst, xdim, ydim, dstBitDepth, nchannels, dstRowBytes);
   }
   catch(OfxuNoImageException &ex) {
@@ -916,7 +911,7 @@ describe(OfxImageEffectHandle  effect)
   if (stat == kOfxStatOK) {
     gHostColourManagementStyle = ofxstring_to_style(tmpStr);
   } else {
-    spdlog::info(FMT_STRING("describe: host does not support colour management (err={})"), errMsg(stat));
+    spdlog::info("describe: host does not support colour management (err={})", errMsg(stat));
     gHostColourManagementStyle = ColourManagementStyle::None;
   }
 
@@ -976,7 +971,7 @@ describe(OfxImageEffectHandle  effect)
       break;
     }
     if (stat != kOfxStatOK) {
-      spdlog::error(FMT_STRING("setting kOfxImageEffectPropColourManagementStyle prop: stat={}"), errMsg(stat));
+      spdlog::error("setting kOfxImageEffectPropColourManagementStyle prop: stat={}", errMsg(stat));
     }
   }
 
@@ -996,7 +991,7 @@ pluginMain(const char *action, const void *handle, OfxPropertySetHandle inArgs, 
   OfxStatus stat = kOfxStatOK;
 
   if (silentActions.find(action) == silentActions.end())
-    spdlog::info(FMT_STRING(">>> pluginMain({})"), action);
+    spdlog::info(">>> pluginMain({})", action);
   try {
   // cast to appropriate type
   OfxImageEffectHandle effect = (OfxImageEffectHandle) handle;
@@ -1045,25 +1040,25 @@ pluginMain(const char *action, const void *handle, OfxPropertySetHandle inArgs, 
   }
   } catch (const std::bad_alloc&) {
     // catch memory
-    spdlog::error(FMT_STRING("Caught OFX Plugin Memory error"));
+    spdlog::error("Caught OFX Plugin Memory error");
     stat = kOfxStatErrMemory;
   } catch ( const std::exception& e ) {
     // standard exceptions
-    spdlog::error(FMT_STRING("Caught OFX Plugin error {}"), e.what());
+    spdlog::error("Caught OFX Plugin error {}", e.what());
     stat = kOfxStatErrUnknown;
   } catch (int err) {
-    spdlog::error(FMT_STRING("Caught misc error {}"), err);
+    spdlog::error("Caught misc error {}", err);
     stat = err;
   } catch ( ... ) {
     // everything else
-    spdlog::error(FMT_STRING("Caught unknown OFX plugin error"));
+    spdlog::error("Caught unknown OFX plugin error");
     stat = kOfxStatErrUnknown;
   }
   // other actions to take the default value
 
 
   if (silentActions.find(action) == silentActions.end())
-    spdlog::info(FMT_STRING("<<< pluginMain({}) = {}"), action, errMsg(stat));
+    spdlog::info("<<< pluginMain({}) = {}", action, errMsg(stat));
   return stat;
 }
 
@@ -1133,7 +1128,7 @@ OfxSetHost()
 struct SharedLibResource {
   SharedLibResource() {
     spdlog::set_level(spdlog::level::trace);
-    spdlog::trace(FMT_STRING("shlib/dll loaded"));
+    spdlog::trace("shlib/dll loaded");
   }
   ~SharedLibResource() {
   }

--- a/Examples/include/ofxSpdlogCompat.h
+++ b/Examples/include/ofxSpdlogCompat.h
@@ -1,0 +1,19 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: off; c-basic-offset: 2 -*- */
+// Copyright OpenFX and contributors to the OpenFX project.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "spdlog/spdlog.h"
+
+// Some build environments opt in to fmt's strict mode via
+// FMT_ENFORCE_COMPILE_STRING, which rejects any non-FMT_STRING format
+// string that fmt can't compile-time-check itself. In C++20 (where fmt's
+// own consteval machinery handles the check), the wrapper is redundant
+// and some older spdlogs trip on FMT_STRING-wrapped plain strings, so
+// we only opt in when fmt itself tells us it cannot consteval-check.
+#if defined(FMT_ENFORCE_COMPILE_STRING) && !FMT_USE_CONSTEVAL && defined(FMT_STRING)
+#  define OFX_FMT_STRING(s) FMT_STRING(s)
+#else
+#  define OFX_FMT_STRING(s) s
+#endif


### PR DESCRIPTION
spdlog since around 1.8 doesn't need FMT_STRING anymore, and it may cause type errors when used on plain strings with no format specs.