### PR TITLE
Fix issue #240: Rectangle example sets RGBA defaults on the wrong param

### DIFF
--- a/Examples/Rectangle/rectangle.cpp
+++ b/Examples/Rectangle/rectangle.cpp
@@ -797,16 +797,16 @@ describeInContext(OfxImageEffectHandle effect, OfxPropertySetHandle inArgs)
   gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 1, 0.6);
   gPropHost->propSetString(paramProps, kOfxParamPropHint, 0, "A corner of the rectangle to draw");
   gPropHost->propSetString(paramProps, kOfxPropLabel, 0, "Corner 2");
-  gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 0, 0);
-  gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 1, 0);
-  gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 2, 0);
-  gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 3, 1);
 
   // make an rgba colour parameter
   gParamHost->paramDefine(paramSet, kOfxParamTypeRGBA, "colour", &paramProps);
   gPropHost->propSetString(paramProps, kOfxParamPropHint, 0, "The colour of the rectangle");
   gPropHost->propSetString(paramProps, kOfxParamPropScriptName, 0, "colour");
   gPropHost->propSetString(paramProps, kOfxPropLabel, 0, "Colour");
+  gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 0, 0);
+  gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 1, 0);
+  gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 2, 0);
+  gPropHost->propSetDouble(paramProps, kOfxParamPropDefault, 3, 1);
 
 
   return kOfxStatOK;


### PR DESCRIPTION
Fixes #240.

As reported by @Babakinha, the Rectangle example set the RGBA colour
default values *before* the `colour` parameter was defined. The four
`kOfxParamPropDefault` calls therefore operated on `corner2`'s property
handle, corrupting its default instead of setting the colour to opaque
black.

This moves the four default-setting calls to immediately after the
`colour` parameter is created, so `paramProps` refers to the colour
param when they run. No other behavior changes.