### PR TITLE
Add SECURITY.md, rename README.md, and fix stale repo URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/standard-change.md
+++ b/.github/ISSUE_TEMPLATE/standard-change.md
@@ -5,7 +5,7 @@ labels: standard change
 ---
 # Open Effects Proposal for Standard Change
 
-Please read the contribution [guidelines](https://github.com/ofxa/openfx/wiki/Extending-OpenFX-Guidelines#submit-a-proposal-or-bug-report-to-review) first.
+Please read the contribution [guidelines](https://github.com/AcademySoftwareFoundation/openfx/blob/main/CONTRIBUTING.md) first.
 
 ## Standard Change Workflow
 - [ ] Create proposal as issue (you're doing this now!)
@@ -18,7 +18,7 @@ Please read the contribution [guidelines](https://github.com/ofxa/openfx/wiki/Ex
    - [ ] Discuss and review code in the PR
    - [ ] Meet all requirements below for accepting PR
 - [ ] When subcommittee signs off and other members don't have any further review comments, 
-      maintainer merges PR to master which closes PR and issue
+      maintainer merges PR to main which closes PR and issue
 
 ## Requirements for accepting a standard change:
 - [ ] Header files updated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ There are several ways to connect with the OpenFX project:
   mail list: This is our primary mailing list, intended for technical
   discussion and help implementing and using OpenFX.
 
-* [GitHub Issues](https://github.com/ofxa/openfx/issues): GitHub
+* [GitHub Issues](https://github.com/AcademySoftwareFoundation/openfx/issues): GitHub
   Issues are used both to track bugs and to discuss feature requests.
 
 * [Slack channel](https://slack.aswf.io/)
@@ -34,7 +34,7 @@ using, or extending OpenFX are the mailing list and our Slack.
 ### How to Report a Bug
 
 OpenFX use GitHub's issue tracking system for bugs and enhancements:
-https://github.com/ofxa/openfx/issues
+https://github.com/AcademySoftwareFoundation/openfx/issues
 
 If you are submitting a bug report, please be sure to note which
 plug-in(s) and host products are involved, what OS and compilers
@@ -49,7 +49,7 @@ with enough detail that others can reproduce the problem.
 
 ### How to Request a Standard Change
 
-Open a GitHub issue: https://github.com/ofxa/openfx/issues.
+Open a GitHub issue: https://github.com/AcademySoftwareFoundation/openfx/issues.
 
 Describe the goal and the proposed feature in as much detail as
 possible. Standard change requests will almost certainly spawn a
@@ -58,7 +58,7 @@ discussion among the project community.
 ### How to Report a Security Vulnerability
 
 If you think you've found a potential vulnerability in OpenFX, please
-refer to [SECURITY.md] to responsibly disclose it.
+refer to [SECURITY.md](SECURITY.md) to responsibly disclose it.
 
 ### How to Contribute a Bug Fix or Change
 
@@ -160,7 +160,7 @@ repository](https://help.github.com/articles/cloning-a-repository/)
 and [Configuring a remote for a
 fork](https://help.github.com/articles/configuring-a-remote-for-a-fork/),
 but again, if you need assistance feel free to reach out on the
-openexr-dev@lists.aswf.io mail list.
+openfx-discussion@lists.aswf.io mail list.
 
 ### Pull Requests
 

--- a/Documentation/sourceforge/index.html
+++ b/Documentation/sourceforge/index.html
@@ -43,7 +43,7 @@ The doxygen documentation extracted from the header files is a useful adjunct to
 <h3>Header Files</h3>
 <para>
 The header files are available as a <a href="http://sourceforge.net/projects/openfx/files/openfx">tarball</a>,
-or you can clone the <a href="http://github.com/ofxa/openfx">git repository</a>.
+or you can clone the <a href="https://github.com/AcademySoftwareFoundation/openfx">git repository</a>.
 </para>
 
 </body>

--- a/Documentation/sources/Guide/ofxExample1_Basics.rst
+++ b/Documentation/sources/Guide/ofxExample1_Basics.rst
@@ -6,7 +6,7 @@ with a host application, and goes into the fundamentals of the API.
 
 An example plugin will be used to illustrate how all the machinery
 works, and its source can be found in the C++ file
-`there <https://github.com/AcademySoftwareFoundation/openfx/blob/master/Guide/Code/Example1/basics.cpp>`__.
+`there <https://github.com/AcademySoftwareFoundation/openfx/blob/main/Guide/Code/Example1/basics.cpp>`__.
 This plugin is a *no-op* image
 effect and does absolutely nothing to images, it is there purely to show
 you the basics of how a host and plugin work together. I’ll embed
@@ -185,10 +185,10 @@ literal string that names the suite. A host will pass a set of suites to
 a plugin, each suite having the set of function pointers filled
 appropriately.
 
-For example, look in the file `ofxMemory.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxMemory.h>`__ for the suite used to perform
+For example, look in the file `ofxMemory.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxMemory.h>`__ for the suite used to perform
 memory allocation:
 
-`ofxMemory.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxMemory.h#L48>`__
+`ofxMemory.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxMemory.h#L48>`__
 
 Notice also, the version number built into the name of the memory suite.
 If we ever needed to change the memory suite for some reason,

--- a/Documentation/sources/Guide/ofxExample2_Invert.rst
+++ b/Documentation/sources/Guide/ofxExample2_Invert.rst
@@ -4,7 +4,7 @@
 This guide will take you through the fundamentals of processing images
 in OFX. An example plugin will be used to illustrate how it all works
 and its source can be found in the C++ file
-`invert.cpp <https://github.com/ofxa/openfx/blob/master/Guide/Code/Example2/invert.cpp>`_.
+`invert.cpp <https://github.com/AcademySoftwareFoundation/openfx/blob/main/Guide/Code/Example2/invert.cpp>`_.
 This plugin takes an image and
 inverts it (or rather calculates the complement of each component).
 Ideally you should have read the guide to the :ref:`basic machinery of an OFX

--- a/Documentation/sources/Guide/ofxExample3_Gain.rst
+++ b/Documentation/sources/Guide/ofxExample3_Gain.rst
@@ -4,7 +4,7 @@
 This guide will take you through the basics of creating and using
 parameters in OFX. An example plugin will be used to illustrate how it
 all works and its source can be found in the C++ file
-`gain.cpp <https://github.com/ofxa/openfx/blob/master/Guide/Code/Example3/gain.cpp>`_.
+`gain.cpp <https://github.com/AcademySoftwareFoundation/openfx/blob/main/Guide/Code/Example3/gain.cpp>`_.
 This plugin takes an image and
 multiplies the pixel by the value held in a user visible parameter.
 Ideally you should have read the guide to the :ref:`basic image

--- a/Documentation/sources/Guide/ofxExample4_Saturation.rst
+++ b/Documentation/sources/Guide/ofxExample4_Saturation.rst
@@ -4,7 +4,7 @@
 This guide will take you through the basics of creating effects that can
 be used in more than one context, as well as how to make a multi-input
 effect. Its source can be found in the C++ file
-`saturation.cpp <https://github.com/ofxa/openfx/blob/master/Guide/Code/Example4/saturation.cpp>`_.
+`saturation.cpp <https://github.com/AcademySoftwareFoundation/openfx/blob/main/Guide/Code/Example4/saturation.cpp>`_.
 This plugin takes an RGB or RGBA
 image and increases or decreases the saturation by a parameter. It can
 be used in two contexts, firstly as a simple filter, secondly as a

--- a/Documentation/sources/Guide/ofxExamples.rst
+++ b/Documentation/sources/Guide/ofxExamples.rst
@@ -86,7 +86,7 @@ This API can be somewhat awkward to use directly, and it is expected
 that most plugin or host developers will wrap the API in higher level C
 or C++ structures.
 
-There are open source host and plugin side API C wrappers available from the `openfx.org git repository <https://github.com/ofxa/openfx>`_.
+There are open source host and plugin side API C wrappers available from the `openfx.org git repository <https://github.com/AcademySoftwareFoundation/openfx>`_.
 As you work through the examples you’ll see that I actually start wrapping up various entities within the API
 into ``C`` classes as it can get unwieldy otherwise.
 

--- a/Documentation/sources/Reference/ofxCoreAPI.rst
+++ b/Documentation/sources/Reference/ofxCoreAPI.rst
@@ -19,12 +19,12 @@ a host application.
 There are two include files that are used with nearly every derived API.
 These are...
 
--  `ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxCore.h>`__
+-  `ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxCore.h>`__
    is used to define the basic communication mechanisms between a host
    and a plug-in. This includes the way in which a plug-in is defined to
    a host and how to bootstrap the two way communications. It also has
    several other basic action and property definitions.
--  `ofxProperty.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxProperty.h>`__
+-  `ofxProperty.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxProperty.h>`__
    specifies the property suite, which is how a plug-in gets and sets
    values on various objects in a host application.
 

--- a/Documentation/sources/Reference/ofxImageClip.rst
+++ b/Documentation/sources/Reference/ofxImageClip.rst
@@ -35,7 +35,7 @@ Components are packed per pixel in the following manner...
 -  RGBA pixels as R, G, B, A
 -  RGB pixels as R, G, B
 
-There are several structs for pixel types in `ofxCore.h <https://github.com/ofxa/openfx/blob/master/include/ofxCore.h>` that can be used
+There are several structs for pixel types in `ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxCore.h>` that can be used
 for raw pixels in OFX.
 
 Images are always left to right, bottom to top, with the pixel data

--- a/Documentation/sources/Reference/ofxImageEffectAPI.rst
+++ b/Documentation/sources/Reference/ofxImageEffectAPI.rst
@@ -26,27 +26,27 @@ Image Effect API Header Files
 
 The header files used to define the OFX Image Effect API are...
 
--  `ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxCore.h>`__
+-  `ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxCore.h>`__
    Provides the core definitions of the general OFX architecture that
    allow the bootstrapping of specific APIs, as well as several core actions,
--  `ofxProperty.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxProperty.h>`__
+-  `ofxProperty.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxProperty.h>`__
     Provides generic property fetching suite used to get and set values about objects in the API,
--  `ofxParam.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxParam.h>`__
+-  `ofxParam.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxParam.h>`__
    Provides the suite for defining user visible parameters to an
    effect
--  `ofxMultiThread.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxMultiThread.h>`__
+-  `ofxMultiThread.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxMultiThread.h>`__
    Provides the suite for basic multi-threading capabilities
--  `ofxInteract.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxInteract.h>`__
+-  `ofxInteract.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxInteract.h>`__
    Provides the suite that allows a plug-in to use OpenGL to draw their own interactive GUI tools
--  `ofxKeySyms.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxKeySyms.h>`__
+-  `ofxKeySyms.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxKeySyms.h>`__
    Provides key symbols used by 'Interacts' to represent keyboard events
--  `ofxMemory.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxMemory.h>`__
+-  `ofxMemory.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxMemory.h>`__
    Provides a simple memory allocation suite,
--  `ofxMessage.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxMessage.h>`__
+-  `ofxMessage.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxMessage.h>`__
    Provides a simple messaging suite to communicate with an end user
--  `ofxImageEffect.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxImageEffect.h>`__
+-  `ofxImageEffect.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxImageEffect.h>`__
    Defines a suite and set of actions that draws all the above together to create an visual effect plug-in.
--  `ofxDrawSuite.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxDrawSuite.h>`__
+-  `ofxDrawSuite.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxDrawSuite.h>`__
    Provides an optional suite that allows a plug-in to draw their own interactive GUI tools without using OpenGL
 
 These contain the suite definitions, property definitions and action
@@ -190,7 +190,7 @@ argument:
 
 The functions that directly manipulate an image effect handle are
 specified in the :cpp:class:`OfxImageEffectSuiteV1` found
-in the header file `ofxImageEffect.h <https://github.com/ofxa/openfx/blob/master/include/ofxImageEffect.h>`_.
+in the header file `ofxImageEffect.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxImageEffect.h>`_.
 
 Effect Descriptors
 ^^^^^^^^^^^^^^^^^^
@@ -307,7 +307,7 @@ differs from a boolean parameter.
 
 Parameters and parameter sets are manipulated via the calls and
 properties in the :cpp:class:`OfxParameterSuiteV1` specified
-in `ofxParam.h <https://github.com/ofxa/openfx/blob/master/include/ofxParam.h>`_.
+in `ofxParam.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxParam.h>`_.
 The properties on parameter instances and
 descriptors can be found in the section :ref:`Properties on Parameter
 Descriptors and Instances <ParameterProperties>`.
@@ -395,7 +395,7 @@ pointer property on an OFX object, for example the
 property on an effect descriptor.
 
 The functions that directly manipulate interacts are in the :cpp:class:`OfxInteractSuiteV1` found in the header file
-`ofxInteract.h <https://github.com/ofxa/openfx/blob/master/include/ofxInteract.h>`_ , as well as the properties and specific actions that
+`ofxInteract.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxInteract.h>`_ , as well as the properties and specific actions that
 apply to interacts.
 
 Interact Descriptors

--- a/Documentation/sources/Reference/ofxImageEffectActions.rst
+++ b/Documentation/sources/Reference/ofxImageEffectActions.rst
@@ -9,9 +9,9 @@ from two categories...
 
 -  actions that could potentially be issued to any kind of plug in, not
    just image effects, known as generic actions, found in
-   `ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxCore.h>`__
+   `ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxCore.h>`__
 -  actions that are only applicable purely to image effects, found in
-   `ofxImageEffect.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxImageEffect.h>`__
+   `ofxImageEffect.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxImageEffect.h>`__
 
 For generic actions, the ``handle`` passed to to main entry point will
 depend on the API being implemented, for all generic actions passed to an

--- a/Documentation/sources/Reference/ofxParameter.rst
+++ b/Documentation/sources/Reference/ofxParameter.rst
@@ -945,7 +945,7 @@ new :cpp:class:`OfxParametricParameterSuiteV1`
 is there to do that.
 
 All the defines and suite definitions for parametric parameters are
-defined in the file `ofxParametricParam.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxParametricParam.h>`__
+defined in the file `ofxParametricParam.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxParametricParam.h>`__
 
 Parametric parameters are in effect *functions* a plug-in can ask a host
 to arbitrarily evaluate for some value *x*. A classic use case would be

--- a/Documentation/sources/Reference/ofxStatusCodes.rst
+++ b/Documentation/sources/Reference/ofxStatusCodes.rst
@@ -6,7 +6,7 @@ Status Codes
 
 Status codes are returned by most functions in OFX suites and all
 plug-in actions to indicate the success or failure of the operation. All
-status codes are defined in `ofxCore.h <https://github.com/ofxa/openfx/blob/master/include/ofxCore.h>`_ and
+status codes are defined in `ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxCore.h>`_ and
 *#defined* to be integers.
 
 .. doxygentypedef:: OfxStatus

--- a/Documentation/sources/Reference/ofxStructure.rst
+++ b/Documentation/sources/Reference/ofxStructure.rst
@@ -47,7 +47,7 @@ Properties are typed value/name pairs that exist on the various OFX
 objects and are action argument values to the plug-in's main entry
 point. They are how a plug-in and host pass individual values back and
 forth to each other. The property suite, defined inside
-`ofxProperty.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxProperty.h>`__
+`ofxProperty.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxProperty.h>`__
 is used to do this.
 
 OFX APIs
@@ -68,7 +68,7 @@ parameter suite could be reused to specify user visible parameters to
 the other APIs.
 
 Several types are common to all OFX APIs, and as such are defined in
-`ofxCore.h <https://github.com/ofxa/openfx/blob/master/include/ofxCore.h>`_.
+`ofxCore.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxCore.h>`_.
 Most objects passed back to a plug-in are generally
 specified by blind data handles, for example:
 

--- a/Documentation/sources/Reference/ofxThreadSafety.rst
+++ b/Documentation/sources/Reference/ofxThreadSafety.rst
@@ -36,7 +36,7 @@ The only actions that can be called on a render thread are...
 
 If a plugin cannot support this multi-threading behaviour, it will need
 to perform explicit locking itself, using the locking mechanisms in the
-suites defined in `ofxMultiThread.h <https://github.com/ofxa/openfx/blob/master/include/ofxMultiThread.h>`_.
+suites defined in `ofxMultiThread.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxMultiThread.h>`_.
 
 This will also mean that the host may need to perform locking on the
 various function calls over the API. For example, a main and render

--- a/Documentation/sources/Reference/suites/ofxDrawSuiteReference.rst
+++ b/Documentation/sources/Reference/suites/ofxDrawSuiteReference.rst
@@ -5,7 +5,7 @@ OfxDrawSuiteV1: Drawing Overlays
 
 Added for OFX v1.5, Jan 2022.
 
-See the source at `ofxDrawSuite.h <https://github.com/AcademySoftwareFoundation/openfx/blob/master/include/ofxDrawSuite.h>`__
+See the source at `ofxDrawSuite.h <https://github.com/AcademySoftwareFoundation/openfx/blob/main/include/ofxDrawSuite.h>`__
 
 .. doxygenstruct:: OfxDrawSuiteV1
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The authoritative source for information about OFX is http://openeffects.org/
 
-* [OpenFX Build Instructions](https://github.com/AcademySoftwareFoundation/openfx/blob/master/install.md)
+* [OpenFX Build Instructions](https://github.com/AcademySoftwareFoundation/openfx/blob/main/install.md)
 * [OpenFX Documentation](https://openfx.readthedocs.io/en/latest) - start here
 * [OpenFX Documentation: Reference](https://openfx.readthedocs.io/en/latest/Reference)
 * [Programming Guide By Example](https://openfx.readthedocs.io/en/latest/Guide)
@@ -34,7 +34,7 @@ An application which allows you build a video clip by layering video clips, stil
 
 ## Contributing
 
-Please read the [Contribution Guidelines](https://github.com/ofxa/openfx/wiki/Extending-OpenFX-Guidelines) for how to submit pull requests for fixes and changes to the standard.
+Please read the [Contribution Guidelines](https://github.com/AcademySoftwareFoundation/openfx/wiki/Extending-OpenFX-Guidelines) for how to submit pull requests for fixes and changes to the standard.
 
 # Building Libs and Plugins
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright OpenFX and contributors to the OpenFX project. -->
+
+# OpenFX Security Policy
+
+## Reporting a Vulnerability
+
+If you think you've found a potential vulnerability in OpenFX, please
+report it privately so that we can investigate and prepare a fix before
+the issue is publicly disclosed. **Do not** open a public GitHub issue,
+post to the mailing list, or otherwise disclose the problem publicly
+before it has been addressed.
+
+Please report vulnerabilities through GitHub's private security advisory
+system, which lets you disclose the issue confidentially to the OpenFX
+maintainers:
+
+https://github.com/AcademySoftwareFoundation/openfx/security/advisories/new
+
+Please include as much detail as you can:
+
+* The version, branch, or commit of OpenFX affected.
+* The component involved (API headers, the C++ support library, the
+  example plug-ins, or the build/release tooling).
+* A description of the vulnerability and its potential impact.
+* Steps to reproduce, ideally with a minimal proof of concept.
+
+We will acknowledge receipt of your report within 5 business days and
+will work with you to understand and resolve the issue promptly. Once a
+fix is available we will coordinate disclosure and credit you for the
+report unless you prefer to remain anonymous.
+
+## Supported Versions
+
+OpenFX is a standard (a set of C API headers) accompanied by a C++
+support library and example plug-ins. Fixes are applied as follows:
+
+| Version       | Supported                                   |
+|---------------|---------------------------------------------|
+| `main` branch | Yes — all fixes land here first             |
+| 1.4.x         | Yes — security fixes backported when feasible |
+| 1.3.x and earlier | No longer receiving patches             |
+
+## Security Model and Expectations
+
+OpenFX defines a binary interface between *host* applications (such as
+compositors and editors) and *plug-ins* that provide image-processing
+effects. Understanding this trust boundary is important when reasoning
+about security:
+
+* **Plug-ins are native code that runs inside the host process.** A host
+  loads OFX plug-ins as dynamic libraries/bundles, and a loaded plug-in
+  has the same privileges as the host. Installing and loading a plug-in
+  is therefore equivalent to running arbitrary native code; hosts and
+  users should only load plug-ins from trusted sources. This is an
+  inherent property of the plug-in model, not a defect in OpenFX.
+
+* **Hosts and plug-ins should treat each other defensively.** Because
+  the API is a boundary between independently developed components,
+  both sides should validate the property values, image data, and
+  pointers they receive across the suite interfaces rather than
+  assuming the other side is well-behaved.
+
+The code maintained in this repository that is most relevant to
+security is:
+
+* The **API header files** in `include/` — the definitions of the
+  suites and properties.
+* The **C++ support library** in `Support/` — helper code that hosts
+  and plug-in authors may compile into their own products. Memory
+  handling, bounds checking, and parsing of host-supplied values in
+  this library are the primary in-repo attack surface.
+* The **example plug-ins** — provided for illustration and not intended
+  for production use.
+
+Issues in third-party host applications or commercial plug-ins are out
+of scope for this repository and should be reported to their respective
+vendors.
+
+## Known Vulnerabilities
+
+There are no known unpatched security vulnerabilities in OpenFX at this
+time.

--- a/STANDARD_PROCESS.md
+++ b/STANDARD_PROCESS.md
@@ -11,7 +11,7 @@ The process is comprised of the following steps:
 ## Proposal
 
 Use the
-[Standard Change Proposal](https://github.com/ofxa/openfx/issues/new?assignees=&labels=standard+change&template=standard-change.md)
+[Standard Change Proposal](https://github.com/AcademySoftwareFoundation/openfx/issues/new?assignees=&labels=standard+change&template=standard-change.md)
 github issue template to file a Standard Change Proposal.
 This template has a number of helpful prompts to guide you in creating
 a useful proposal.

--- a/release-notes.md
+++ b/release-notes.md
@@ -5,7 +5,7 @@ This is the release 1.5.1 of OFX, the Open Effects image-processing plug-in stan
 Documentation and more info can be found at:
 
 * [The OpenFX website](http://openeffects.org)
-* [OFX Programming Guide By Example](https://github.com/ofxa/openfx/tree/master/Guide)
+* [OFX Programming Guide By Example](https://github.com/AcademySoftwareFoundation/openfx/tree/main/Guide)
 * [OFX API v. 1.4 Reference](http://openeffects.org/documentation/api_doc)
 * [OFX API Programming Guide](http://openeffects.org/documentation/guide)
 * [OFX API Programming Reference](http://openeffects.org/documentation/reference)

--- a/scripts/build-cmake.sh
+++ b/scripts/build-cmake.sh
@@ -91,7 +91,7 @@ fi
 
 if [[ ! -f ./conanfile.py ]]; then
     echo "***"
-    echo "*** ERROR: please run this script from the top level dir, where conanfile.py and readme.md are."
+    echo "*** ERROR: please run this script from the top level dir, where conanfile.py and README.md are."
     echo "***"
     exit 1
 fi


### PR DESCRIPTION
Addresses the OpenFX findings from the ASWF project health report.

## Changes

**SECURITY.md (new)** — adds a security policy at the repo root: vulnerability reporting via GitHub private security advisories, a 5-business-day acknowledgment SLA, a supported-versions table, and an OpenFX-specific security model section (the host/plug-in trust boundary — plug-ins are native code loaded into the host process).

**README** — renamed `readme.md` → `README.md` so GitHub surfaces it automatically. This also repairs the already-uppercase references in `conanfile.py` and `pyproject.toml`, and the casing reference in `scripts/build-cmake.sh`.

**CONTRIBUTING.md**
- Fixed three issue-tracker URLs: `github.com/ofxa/openfx` → `github.com/AcademySoftwareFoundation/openfx`.
- Fixed the copy-pasted mailing list `openexr-dev@lists.aswf.io` → `openfx-discussion@lists.aswf.io`.
- Fixed the broken `[SECURITY.md]` reference to a working link now that the file exists.

**Repo-wide URL cleanup** — replaced all remaining stale `ofxa/openfx` references and updated repo-relative links from the old `master` branch to `main` across `README.md`, `STANDARD_PROCESS.md`, `release-notes.md`, `Documentation/sourceforge/index.html`, and the `Documentation/sources/**/*.rst` files (also upgraded one `http://` link to `https://`).

After this change there are zero remaining `ofxa/openfx` references and zero `openfx/{blob,tree,raw}/master` links in the tree.