### PR TITLE
CI: pin Windows CUDA build to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,9 @@ jobs:
           - name_prefix: Windows
             release_prefix: windows
             ostype: windows
-            os: windows-latest
+            # Pin to VS2022; CUDA 12.4 nvcc rejects the VS2026 host compiler
+            # shipped on windows-latest. See host_config.h version check.
+            os: windows-2022
             has_cmake_presets: true
             buildtype: Release
             conan_version: 2.20.1


### PR DESCRIPTION
## Problem

The **Windows `<config=Release>`** (CUDA) CI job started failing on all PRs and pushes. It dies at CMake configure time during CUDA compiler detection, before any source is compiled:

```
crt/host_config.h(170): fatal error C1189: #error: -- unsupported Microsoft
Visual Studio version! Only the versions between 2017 and 2022 (inclusive)
are supported!
...
CMakeLists.txt:3 (project)
```

GitHub rolled the `windows-latest` runner image forward to **Visual Studio 2026** (log paths show `Visual Studio\18\Enterprise`). The pinned **CUDA 12.4.1** toolkit's `nvcc` only accepts host compilers VS 2017–2022, so it rejects the new `cl.exe`.

This is purely runner-image drift — no source change triggered it (the last `main` build was green; the non-CUDA Windows job, which doesn't invoke `nvcc`, still passes).

## Fix

Pin the CUDA Windows matrix entry to `windows-2022`, which still provides VS 2022. The non-CUDA Windows job stays on `windows-latest` so we keep coverage of the newer toolchain.

This is a stopgap until a CUDA toolkit that supports VS 2026 can be adopted on Windows.