### PR TITLE
Restructure Conan package to standard CCI layout (#238)

### DIFF
--- a/cmake/OpenFX.cmake
+++ b/cmake/OpenFX.cmake
@@ -46,7 +46,23 @@ function(add_ofx_plugin TARGET)
   set(BUNDLE_SIGNATURE "????")  # any value is OK here, ignored by modern MacOS
   set(PLUGIN_VERSION "1.0.0")
 
-  configure_file(${CMAKE_SOURCE_DIR}/Examples/Info.plist.in
+  # Locate the Info.plist template. In the OpenFX source tree it lives in
+  # Examples/; in an installed/Conan package it sits next to this module
+  # (lib/cmake/). CMAKE_CURRENT_LIST_DIR is the directory of this module file,
+  # so this resolves correctly regardless of the consumer's CMAKE_SOURCE_DIR.
+  set(_ofx_info_plist "")
+  foreach(_dir "${CMAKE_CURRENT_LIST_DIR}"
+               "${CMAKE_CURRENT_LIST_DIR}/../Examples"
+               "${CMAKE_SOURCE_DIR}/Examples")
+    if(EXISTS "${_dir}/Info.plist.in")
+      set(_ofx_info_plist "${_dir}/Info.plist.in")
+      break()
+    endif()
+  endforeach()
+  if(NOT _ofx_info_plist)
+    message(FATAL_ERROR "add_ofx_plugin: could not find Info.plist.in")
+  endif()
+  configure_file("${_ofx_info_plist}"
                  "${PLUGIN_INSTALLDIR}/${TARGET}.ofx.bundle/Contents/Info.plist")
 
   # Set symbol visibility hidden. Individual symbols are exposed via

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,9 +20,9 @@ class openfx(ConanFile):
 		"scripts/*",
 		"Support/*",
 		"CMakeLists.txt",
-		"LICENSE",
+		"LICENSE*",
 		"README.md",
-		"INSTALL.md"
+		"install.md"
 	)
 
 	settings = "os", "arch", "compiler", "build_type"
@@ -59,26 +59,54 @@ class openfx(ConanFile):
 		cmake.build()
 
 	def package(self):
-		copy(self, "cmake/*", src=self.source_folder, dst=self.package_folder)
-		copy(self, "LICENSE, README.md, INSTALL.md", src=self.source_folder, dst=self.package_folder)
-		copy(self, "include/*.h", src=self.source_folder, dst=self.package_folder)
-		copy(self,"HostSupport/include/*.h", src=self.source_folder, dst=self.package_folder)
-		copy(self,"Support/*.h", src=self.source_folder, dst=self.package_folder)
-		copy(self,"Support/Plugins/include/*.h", src=self.source_folder, dst=self.package_folder)
-		copy(self,"*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
-		copy(self,"*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
-		copy(self,"*.ofx", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
-		copy(self,"*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
-		copy(self,"*.so", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+		src = self.source_folder
+		pkg = self.package_folder
+		inc = os.path.join(pkg, "include")
+
+		# Headers, all under include/ following the standard layout. The OFX C
+		# API headers sit at the root; the host- and plugin-support headers go
+		# into namespaced subdirectories.
+		copy(self, "*.h", src=os.path.join(src, "include"), dst=inc)
+		copy(self, "*.h", src=os.path.join(src, "HostSupport", "include"),
+		     dst=os.path.join(inc, "HostSupport"))
+		copy(self, "*.h", src=os.path.join(src, "Support", "include"),
+		     dst=os.path.join(inc, "Support"))
+		# Plugin support helper headers use a .H extension; match both cases.
+		copy(self, "*.[hH]", src=os.path.join(src, "Support", "Plugins", "include"),
+		     dst=os.path.join(inc, "Support", "Plugins"))
+
+		# The CMake build module (add_ofx_plugin) goes in lib/cmake, alongside
+		# the Info.plist template it needs, so it resolves relative to itself
+		# when consumed from the package (see cmake/OpenFX.cmake).
+		cmake_dst = os.path.join(pkg, "lib", "cmake")
+		copy(self, "OpenFX.cmake", src=os.path.join(src, "cmake"), dst=cmake_dst)
+		copy(self, "Info.plist.in", src=os.path.join(src, "Examples"), dst=cmake_dst)
+
+		# License in a per-package subdir so installing many packages into one
+		# prefix (as aswf-docker does) doesn't clash; other docs under res/.
+		copy(self, "LICENSE*", src=src, dst=os.path.join(pkg, "licenses", "openfx"))
+		copy(self, "README.md", src=src, dst=os.path.join(pkg, "res", "openfx"))
+		copy(self, "install.md", src=src, dst=os.path.join(pkg, "res", "openfx"))
+
+		# Static libraries, then any built example plugins.
+		lib = os.path.join(pkg, "lib")
+		bin = os.path.join(pkg, "bin")
+		copy(self, "*.a", src=self.build_folder, dst=lib, keep_path=False)
+		copy(self, "*.lib", src=self.build_folder, dst=lib, keep_path=False)
+		copy(self, "*.ofx", src=self.build_folder, dst=bin, keep_path=False)
+		copy(self, "*.dll", src=self.build_folder, dst=bin, keep_path=False)
+		copy(self, "*.so", src=self.build_folder, dst=bin, keep_path=False)
 
 	def package_info(self):
 		libs = collect_libs(self)
 
-		self.cpp_info.set_property("cmake_build_modules", [os.path.join("cmake", "OpenFX.cmake")])
+		self.cpp_info.set_property("cmake_build_modules", [os.path.join("lib", "cmake", "OpenFX.cmake")])
 		self.cpp_info.components["Api"].includedirs = ["include"]
 		self.cpp_info.components["HostSupport"].libs = [i for i in libs if "OfxHost" in i]
-		self.cpp_info.components["HostSupport"].includedirs = ["HostSupport/include"]
-		self.cpp_info.components["HostSupport"].requires = ["expat::expat"]
+		self.cpp_info.components["HostSupport"].includedirs = ["include/HostSupport"]
+		# spdlog is used by the example/host logging helpers (header-only here).
+		self.cpp_info.components["HostSupport"].requires = ["expat::expat", "spdlog::spdlog"]
 		self.cpp_info.components["Support"].libs = [i for i in libs if "OfxSupport" in i]
-		self.cpp_info.components["Support"].includedirs = ["Support/include"]
-		self.cpp_info.components["Support"].requires = ["opengl::opengl"]
+		self.cpp_info.components["Support"].includedirs = ["include/Support", "include/Support/Plugins"]
+		# cimg is used by the support example plugins to draw text (header-only).
+		self.cpp_info.components["Support"].requires = ["opengl::opengl", "cimg::cimg"]


### PR DESCRIPTION
Reorganizes the Conan package to the standard CCI / aswf-docker layout, per
#238 (thanks @jfpanisset).

| Before | After |
|---|---|
| `include/*.h` | `include/*.h` (OFX C API, unchanged) |
| `HostSupport/include/*.h` | `include/HostSupport/*.h` |
| `Support/include/*.h`, `Support/Plugins/include/*.H` | `include/Support/*.h`, `include/Support/Plugins/*.H` |
| `cmake/OpenFX.cmake` | `lib/cmake/OpenFX.cmake` (+ `Info.plist.in` co-located) |
| `LICENSE` etc. at root | `licenses/openfx/`, docs in `res/openfx/` |

`package_info()` is updated to match. `OpenFX.cmake` now finds `Info.plist.in`
relative to itself (`CMAKE_CURRENT_LIST_DIR`) so `add_ofx_plugin` works when
consumed from the package, not just in-tree. Licenses go in a per-package subdir
so multi-package installs (aswf-docker) don't clash.

Fixes a few latent recipe bugs in passing: docs were never actually packaged
(invalid copy pattern + wrong case), Support headers were copied from the wrong
path, the `.H` plugin headers were missed on case-sensitive filesystems, and
`cimg`/`spdlog` weren't claimed by any component (which errors under modern Conan).

Tested with `conan create` and `test_package`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)