### PR TITLE
Fix incorrect @propdef enum value names + add regression guard (#247)

### DIFF
--- a/Documentation/sources/Reference/ofxPropertiesReferenceGenerated.rst
+++ b/Documentation/sources/Reference/ofxPropertiesReferenceGenerated.rst
@@ -112,6 +112,17 @@ Integer (Boolean) Properties
 - **Used in Property Sets**: :ref:`EffectDescriptor <propset_EffectDescriptor>` (plugin)
 - **Doc**: For detailed doc, see :c:macro:`kOfxImageEffectPluginPropHostFrameThreading`.
 
+.. _prop_OfxImageEffectPluginPropObsolete:
+
+**OfxImageEffectPluginPropObsolete**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **C #define**: :c:macro:`kOfxImageEffectPluginPropObsolete`
+- **Type**: bool
+- **Dimension**: 1
+- **Used in Property Sets**: :ref:`EffectDescriptor <propset_EffectDescriptor>` (plugin)
+- **Doc**: For detailed doc, see :c:macro:`kOfxImageEffectPluginPropObsolete`.
+
 .. _prop_OfxImageEffectPluginPropSingleInstance:
 
 **OfxImageEffectPluginPropSingleInstance**
@@ -957,12 +968,12 @@ Enumeration Properties
 - **Dimension**: 1
 - **Used in Property Sets**: :ref:`ClipDescriptor <propset_ClipDescriptor>` (plugin), :ref:`ClipInstance <propset_ClipInstance>` (host)
 - **Valid Values**:
-  - ``OfxImageFieldNone``
-  - ``OfxImageFieldLower``
-  - ``OfxImageFieldUpper``
-  - ``OfxImageFieldBoth``
-  - ``OfxImageFieldSingle``
-  - ``OfxImageFieldDoubled``
+  - ``OfxFieldNone``
+  - ``OfxFieldLower``
+  - ``OfxFieldUpper``
+  - ``OfxFieldBoth``
+  - ``OfxFieldSingle``
+  - ``OfxFieldDoubled``
 - **Doc**: For detailed doc, see :c:macro:`kOfxImageClipPropFieldExtraction`.
 
 .. _prop_OfxImageClipPropFieldOrder:
@@ -975,9 +986,9 @@ Enumeration Properties
 - **Dimension**: 1
 - **Used in Property Sets**: :ref:`ClipInstance <propset_ClipInstance>` (host)
 - **Valid Values**:
-  - ``OfxImageFieldNone``
-  - ``OfxImageFieldLower``
-  - ``OfxImageFieldUpper``
+  - ``OfxFieldNone``
+  - ``OfxFieldLower``
+  - ``OfxFieldUpper``
 - **Doc**: For detailed doc, see :c:macro:`kOfxImageClipPropFieldOrder`.
 
 .. _prop_OfxImageClipPropUnmappedComponents:
@@ -1023,9 +1034,9 @@ Enumeration Properties
 - **Dimension**: 1
 - **Used in Property Sets**: :ref:`ImageEffectHost <propset_ImageEffectHost>` (host)
 - **Valid Values**:
-  - ``OfxImageEffectHostPropNativeOriginBottomLeft``
-  - ``OfxImageEffectHostPropNativeOriginTopLeft``
-  - ``OfxImageEffectHostPropNativeOriginCenter``
+  - ``kOfxImageEffectHostPropNativeOriginBottomLeft``
+  - ``kOfxImageEffectHostPropNativeOriginTopLeft``
+  - ``kOfxImageEffectHostPropNativeOriginCenter``
 - **Doc**: For detailed doc, see :c:macro:`kOfxImageEffectHostPropNativeOrigin`.
 
 .. _prop_OfxImageEffectPluginRenderThreadSafety:
@@ -1068,11 +1079,11 @@ Enumeration Properties
 - **Dimension**: 1
 - **Used in Property Sets**: :ref:`EffectDescriptor <propset_EffectDescriptor>` (plugin), :ref:`EffectInstance <propset_EffectInstance>` (host), :ref:`ImageEffectHost <propset_ImageEffectHost>` (host)
 - **Valid Values**:
-  - ``OfxImageEffectPropColourManagementNone``
-  - ``OfxImageEffectPropColourManagementBasic``
-  - ``OfxImageEffectPropColourManagementCore``
-  - ``OfxImageEffectPropColourManagementFull``
-  - ``OfxImageEffectPropColourManagementOCIO``
+  - ``OfxImageEffectColourManagementNone``
+  - ``OfxImageEffectColourManagementBasic``
+  - ``OfxImageEffectColourManagementCore``
+  - ``OfxImageEffectColourManagementFull``
+  - ``OfxImageEffectColourManagementOCIO``
 - **Introduced in**: version 1.5
 - **Doc**: For detailed doc, see :c:macro:`kOfxImageEffectPropColourManagementStyle`.
 
@@ -1147,10 +1158,10 @@ Enumeration Properties
 - **Type**: enum
 - **Dimension**: 1
 - **Valid Values**:
-  - ``OfxImageFieldNone``
-  - ``OfxImageFieldBoth``
-  - ``OfxImageFieldLower``
-  - ``OfxImageFieldUpper``
+  - ``OfxFieldNone``
+  - ``OfxFieldBoth``
+  - ``OfxFieldLower``
+  - ``OfxFieldUpper``
 - **Doc**: For detailed doc, see :c:macro:`kOfxImageEffectPropFieldToRender`.
 
 .. _prop_OfxImageEffectPropMetalRenderSupported:
@@ -1255,8 +1266,8 @@ Enumeration Properties
 - **Used in Property Sets**: :ref:`ClipInstance <propset_ClipInstance>` (host), :ref:`Image <propset_Image>` (host)
 - **Valid Values**:
   - ``OfxImageOpaque``
-  - ``OfxImagePreMultiplied``
-  - ``OfxImageUnPreMultiplied``
+  - ``OfxImageAlphaPremultiplied``
+  - ``OfxImageAlphaUnPremultiplied``
 - **Doc**: For detailed doc, see :c:macro:`kOfxImageEffectPropPreMultiplication`.
 
 .. _prop_OfxImageEffectPropSupportedComponents:
@@ -1334,10 +1345,10 @@ Enumeration Properties
 - **Dimension**: 1
 - **Used in Property Sets**: :ref:`Image <propset_Image>` (host)
 - **Valid Values**:
-  - ``OfxImageFieldNone``
-  - ``OfxImageFieldBoth``
-  - ``OfxImageFieldLower``
-  - ``OfxImageFieldUpper``
+  - ``OfxFieldNone``
+  - ``OfxFieldBoth``
+  - ``OfxFieldLower``
+  - ``OfxFieldUpper``
 - **Doc**: For detailed doc, see :c:macro:`kOfxImagePropField`.
 
 .. _prop_OfxOpenGLPropPixelDepth:

--- a/Documentation/sources/Reference/ofxPropertySetsGenerated.rst
+++ b/Documentation/sources/Reference/ofxPropertySetsGenerated.rst
@@ -104,6 +104,7 @@ These property sets represent collections of properties associated with various 
 - :ref:`OfxImageEffectPluginPropFieldRenderTwiceAlways <prop_OfxImageEffectPluginPropFieldRenderTwiceAlways>` - Type: bool, Dimension: 1 (doc: :c:macro:`kOfxImageEffectPluginPropFieldRenderTwiceAlways`)
 - :ref:`OfxImageEffectPluginPropGrouping <prop_OfxImageEffectPluginPropGrouping>` - Type: string, Dimension: 1 (doc: :c:macro:`kOfxImageEffectPluginPropGrouping`)
 - :ref:`OfxImageEffectPluginPropHostFrameThreading <prop_OfxImageEffectPluginPropHostFrameThreading>` - Type: bool, Dimension: 1 (doc: :c:macro:`kOfxImageEffectPluginPropHostFrameThreading`)
+- :ref:`OfxImageEffectPluginPropObsolete <prop_OfxImageEffectPluginPropObsolete>` - Type: bool, Dimension: 1 (doc: :c:macro:`kOfxImageEffectPluginPropObsolete`)
 - :ref:`OfxImageEffectPluginPropOverlayInteractV1 <prop_OfxImageEffectPluginPropOverlayInteractV1>` - Type: pointer, Dimension: 1 (doc: :c:macro:`kOfxImageEffectPluginPropOverlayInteractV1`)
 - :ref:`OfxImageEffectPluginPropOverlayInteractV2 <prop_OfxImageEffectPluginPropOverlayInteractV2>` - Type: pointer, Dimension: 1 (doc: :c:macro:`kOfxImageEffectPluginPropOverlayInteractV2`)
 - :ref:`OfxImageEffectPluginPropSingleInstance <prop_OfxImageEffectPluginPropSingleInstance>` - Type: bool, Dimension: 1 (doc: :c:macro:`kOfxImageEffectPluginPropSingleInstance`)

--- a/include/ofxColour.h
+++ b/include/ofxColour.h
@@ -55,11 +55,11 @@ effect instance.
    type: enum
    dimension: 1
    values:
-     - OfxImageEffectPropColourManagementNone
-     - OfxImageEffectPropColourManagementBasic
-     - OfxImageEffectPropColourManagementCore
-     - OfxImageEffectPropColourManagementFull
-     - OfxImageEffectPropColourManagementOCIO
+     - OfxImageEffectColourManagementNone
+     - OfxImageEffectColourManagementBasic
+     - OfxImageEffectColourManagementCore
+     - OfxImageEffectColourManagementFull
+     - OfxImageEffectColourManagementOCIO
    introduced: "1.5"
 */
 #define kOfxImageEffectPropColourManagementStyle "OfxImageEffectPropColourManagementStyle"

--- a/include/ofxImageEffect.h
+++ b/include/ofxImageEffect.h
@@ -897,9 +897,14 @@ This property is set to indicate whether the effect is currently being rendered 
 */
 #define kOfxImageEffectPropSequentialRenderStatus "OfxImageEffectPropSequentialRenderStatus"
 
-#define kOfxHostNativeOriginBottomLeft   "kOfxImageEffectHostPropNativeOriginBottomLeft"  
-#define kOfxHostNativeOriginTopLeft      "kOfxImageEffectHostPropNativeOriginTopLeft"  
-#define kOfxHostNativeOriginCenter       "kOfxImageEffectHostPropNativeOriginCenter"  
+/* NOTE: these constants are irregularly named: the macro name differs from the
+   string value, and unusually the string value itself begins with "k" (e.g.
+   kOfxHostNativeOriginBottomLeft is "kOfxImageEffectHostPropNativeOriginBottomLeft").
+   The string values are fixed by ABI and cannot change. Do not copy this in new
+   constants; values should not begin with "k". */
+#define kOfxHostNativeOriginBottomLeft   "kOfxImageEffectHostPropNativeOriginBottomLeft"
+#define kOfxHostNativeOriginTopLeft      "kOfxImageEffectHostPropNativeOriginTopLeft"
+#define kOfxHostNativeOriginCenter       "kOfxImageEffectHostPropNativeOriginCenter"
 /** @brief Property that indicates the host native UI space - this is only a UI hint, has no impact on pixel processing
 
 This property is set to kOfxHostNativeOriginBottomLeft pre V1.4 and was to be discovered by plug-ins. This is useful for drawing overlay for points... so everything matches the rest of the app (for example expression linking to other tools, or simply match the reported location of the host viewer).
@@ -912,9 +917,9 @@ This property is set to kOfxHostNativeOriginBottomLeft pre V1.4 and was to be di
    type: enum
    dimension: 1
    values:
-     - OfxImageEffectHostPropNativeOriginBottomLeft
-     - OfxImageEffectHostPropNativeOriginTopLeft
-     - OfxImageEffectHostPropNativeOriginCenter
+     - kOfxImageEffectHostPropNativeOriginBottomLeft
+     - kOfxImageEffectHostPropNativeOriginTopLeft
+     - kOfxImageEffectHostPropNativeOriginCenter
 */
 #define kOfxImageEffectHostPropNativeOrigin  "OfxImageEffectHostPropNativeOrigin"
 
@@ -1178,14 +1183,18 @@ See the documentation on clip preferences for more details on how this is used w
    dimension: 1
    values:
      - OfxImageOpaque
-     - OfxImagePreMultiplied
-     - OfxImageUnPreMultiplied
+     - OfxImageAlphaPremultiplied
+     - OfxImageAlphaUnPremultiplied
 */
 #define kOfxImageEffectPropPreMultiplication "OfxImageEffectPropPreMultiplication"
 
 /** Used to flag the alpha of an image as opaque */
 #define kOfxImageOpaque  "OfxImageOpaque"
 
+/* NOTE: the two constants below are irregularly named: the string value differs
+   from the macro name (it inserts "Alpha" and changes case, e.g.
+   kOfxImagePreMultiplied is "OfxImageAlphaPremultiplied"). The string values are
+   fixed by ABI and cannot change. Do not copy this mismatch in new constants. */
 /** Used to flag an image as premultiplied */
 #define kOfxImagePreMultiplied "OfxImageAlphaPremultiplied"
 
@@ -1491,9 +1500,9 @@ This contains the duration of the plug-in effect, in frames.
     type: enum
     dimension: 1
     values:
-      - OfxImageFieldNone
-      - OfxImageFieldLower
-      - OfxImageFieldUpper
+      - OfxFieldNone
+      - OfxFieldLower
+      - OfxFieldUpper
  */
 #define kOfxImageClipPropFieldOrder "OfxImageClipPropFieldOrder"
 
@@ -1575,10 +1584,10 @@ Row bytes is not supported for OpenCL Images.
     type: enum
     dimension: 1
     values:
-      - OfxImageFieldNone
-      - OfxImageFieldBoth
-      - OfxImageFieldLower
-      - OfxImageFieldUpper
+      - OfxFieldNone
+      - OfxFieldBoth
+      - OfxFieldLower
+      - OfxFieldUpper
  */
 #define kOfxImagePropField "OfxImagePropField"
 
@@ -1607,12 +1616,12 @@ Note that if it fetches kOfxImageFieldSingle and the host stores images natively
     type: enum
     dimension: 1
     values:
-      - OfxImageFieldNone
-      - OfxImageFieldLower
-      - OfxImageFieldUpper
-      - OfxImageFieldBoth
-      - OfxImageFieldSingle
-      - OfxImageFieldDoubled
+      - OfxFieldNone
+      - OfxFieldLower
+      - OfxFieldUpper
+      - OfxFieldBoth
+      - OfxFieldSingle
+      - OfxFieldDoubled
  */
 #define kOfxImageClipPropFieldExtraction "OfxImageClipPropFieldExtraction"
 
@@ -1627,10 +1636,10 @@ Note that if it fetches kOfxImageFieldSingle and the host stores images natively
     type: enum
     dimension: 1
     values:
-      - OfxImageFieldNone
-      - OfxImageFieldBoth
-      - OfxImageFieldLower
-      - OfxImageFieldUpper
+      - OfxFieldNone
+      - OfxFieldBoth
+      - OfxFieldLower
+      - OfxFieldUpper
  */
 #define kOfxImageEffectPropFieldToRender "OfxImageEffectPropFieldToRender"
 
@@ -1672,6 +1681,10 @@ This will be in \ref PixelCoordinates
  */
 #define kOfxImageEffectPropRenderWindow "OfxImageEffectPropRenderWindow"
 
+/* NOTE: these kOfxImageField* constants are irregularly named: the macro name
+   contains "Image" but the string value does not (e.g. kOfxImageFieldNone is
+   "OfxFieldNone", not "OfxImageFieldNone"). The string values are fixed by ABI
+   and cannot change. Do not copy this name/value mismatch in new constants. */
 /** String used to label imagery as having no fields */
 #define kOfxImageFieldNone "OfxFieldNone"
 /** String used to label the lower field (scan lines 0,2,4...) of fielded imagery */

--- a/openfx-cpp/include/openfx/ofxPropsMetadata.h
+++ b/openfx-cpp/include/openfx/ofxPropsMetadata.h
@@ -221,21 +221,21 @@ enum class PropId {
 // Separate arrays for enum-values for enum props, to keep everything constexpr
 namespace prop_enum_values {
 constexpr std::array OfxImageClipPropFieldExtraction =
-  {"OfxImageFieldNone","OfxImageFieldLower","OfxImageFieldUpper","OfxImageFieldBoth","OfxImageFieldSingle","OfxImageFieldDoubled"};
+  {"OfxFieldNone","OfxFieldLower","OfxFieldUpper","OfxFieldBoth","OfxFieldSingle","OfxFieldDoubled"};
 constexpr std::array OfxImageClipPropFieldOrder =
-  {"OfxImageFieldNone","OfxImageFieldLower","OfxImageFieldUpper"};
+  {"OfxFieldNone","OfxFieldLower","OfxFieldUpper"};
 constexpr std::array OfxImageClipPropUnmappedComponents =
   {"OfxImageComponentNone","OfxImageComponentRGBA","OfxImageComponentRGB","OfxImageComponentAlpha"};
 constexpr std::array OfxImageClipPropUnmappedPixelDepth =
   {"OfxBitDepthNone","OfxBitDepthByte","OfxBitDepthShort","OfxBitDepthHalf","OfxBitDepthFloat"};
 constexpr std::array OfxImageEffectHostPropNativeOrigin =
-  {"OfxImageEffectHostPropNativeOriginBottomLeft","OfxImageEffectHostPropNativeOriginTopLeft","OfxImageEffectHostPropNativeOriginCenter"};
+  {"kOfxImageEffectHostPropNativeOriginBottomLeft","kOfxImageEffectHostPropNativeOriginTopLeft","kOfxImageEffectHostPropNativeOriginCenter"};
 constexpr std::array OfxImageEffectPluginRenderThreadSafety =
   {"OfxImageEffectRenderUnsafe","OfxImageEffectRenderInstanceSafe","OfxImageEffectRenderFullySafe"};
 constexpr std::array OfxImageEffectPropCPURenderSupported =
   {"false","true"};
 constexpr std::array OfxImageEffectPropColourManagementStyle =
-  {"OfxImageEffectPropColourManagementNone","OfxImageEffectPropColourManagementBasic","OfxImageEffectPropColourManagementCore","OfxImageEffectPropColourManagementFull","OfxImageEffectPropColourManagementOCIO"};
+  {"OfxImageEffectColourManagementNone","OfxImageEffectColourManagementBasic","OfxImageEffectColourManagementCore","OfxImageEffectColourManagementFull","OfxImageEffectColourManagementOCIO"};
 constexpr std::array OfxImageEffectPropComponents =
   {"OfxImageComponentNone","OfxImageComponentRGBA","OfxImageComponentRGB","OfxImageComponentAlpha"};
 constexpr std::array OfxImageEffectPropContext =
@@ -245,7 +245,7 @@ constexpr std::array OfxImageEffectPropCudaRenderSupported =
 constexpr std::array OfxImageEffectPropCudaStreamSupported =
   {"false","true","needed"};
 constexpr std::array OfxImageEffectPropFieldToRender =
-  {"OfxImageFieldNone","OfxImageFieldBoth","OfxImageFieldLower","OfxImageFieldUpper"};
+  {"OfxFieldNone","OfxFieldBoth","OfxFieldLower","OfxFieldUpper"};
 constexpr std::array OfxImageEffectPropMetalRenderSupported =
   {"false","true","needed"};
 constexpr std::array OfxImageEffectPropNoSpatialAwareness =
@@ -259,7 +259,7 @@ constexpr std::array OfxImageEffectPropOpenGLRenderSupported =
 constexpr std::array OfxImageEffectPropPixelDepth =
   {"OfxBitDepthNone","OfxBitDepthByte","OfxBitDepthShort","OfxBitDepthHalf","OfxBitDepthFloat"};
 constexpr std::array OfxImageEffectPropPreMultiplication =
-  {"OfxImageOpaque","OfxImagePreMultiplied","OfxImageUnPreMultiplied"};
+  {"OfxImageOpaque","OfxImageAlphaPremultiplied","OfxImageAlphaUnPremultiplied"};
 constexpr std::array OfxImageEffectPropSupportedComponents =
   {"OfxImageComponentNone","OfxImageComponentRGBA","OfxImageComponentRGB","OfxImageComponentAlpha"};
 constexpr std::array OfxImageEffectPropSupportedContexts =
@@ -269,7 +269,7 @@ constexpr std::array OfxImageEffectPropSupportedPixelDepths =
 constexpr std::array OfxImageEffectPropThumbnailRender =
   {"false","true"};
 constexpr std::array OfxImagePropField =
-  {"OfxImageFieldNone","OfxImageFieldBoth","OfxImageFieldLower","OfxImageFieldUpper"};
+  {"OfxFieldNone","OfxFieldBoth","OfxFieldLower","OfxFieldUpper"};
 constexpr std::array OfxOpenGLPropPixelDepth =
   {"OfxBitDepthNone","OfxBitDepthByte","OfxBitDepthShort","OfxBitDepthHalf","OfxBitDepthFloat"};
 constexpr std::array OfxParamPropCacheInvalidation =
@@ -1258,5 +1258,107 @@ static_assert(string_view("OfxPropVersionLabel") == string_view(kOfxPropVersionL
 static_assert(string_view("kOfxParamPropUseHostOverlayHandle") == string_view(kOfxParamPropUseHostOverlayHandle));
 static_assert(string_view("kOfxPropKeyString") == string_view(kOfxPropKeyString));
 static_assert(string_view("kOfxPropKeySym") == string_view(kOfxPropKeySym));
+
+// ... and enum values vs their #defines
+static_assert(string_view("OfxFieldNone") == string_view(kOfxImageFieldNone));
+static_assert(string_view("OfxFieldLower") == string_view(kOfxImageFieldLower));
+static_assert(string_view("OfxFieldUpper") == string_view(kOfxImageFieldUpper));
+static_assert(string_view("OfxFieldBoth") == string_view(kOfxImageFieldBoth));
+static_assert(string_view("OfxFieldSingle") == string_view(kOfxImageFieldSingle));
+static_assert(string_view("OfxFieldDoubled") == string_view(kOfxImageFieldDoubled));
+static_assert(string_view("OfxFieldNone") == string_view(kOfxImageFieldNone));
+static_assert(string_view("OfxFieldLower") == string_view(kOfxImageFieldLower));
+static_assert(string_view("OfxFieldUpper") == string_view(kOfxImageFieldUpper));
+static_assert(string_view("OfxImageComponentNone") == string_view(kOfxImageComponentNone));
+static_assert(string_view("OfxImageComponentRGBA") == string_view(kOfxImageComponentRGBA));
+static_assert(string_view("OfxImageComponentRGB") == string_view(kOfxImageComponentRGB));
+static_assert(string_view("OfxImageComponentAlpha") == string_view(kOfxImageComponentAlpha));
+static_assert(string_view("OfxBitDepthNone") == string_view(kOfxBitDepthNone));
+static_assert(string_view("OfxBitDepthByte") == string_view(kOfxBitDepthByte));
+static_assert(string_view("OfxBitDepthShort") == string_view(kOfxBitDepthShort));
+static_assert(string_view("OfxBitDepthHalf") == string_view(kOfxBitDepthHalf));
+static_assert(string_view("OfxBitDepthFloat") == string_view(kOfxBitDepthFloat));
+static_assert(string_view("kOfxImageEffectHostPropNativeOriginBottomLeft") == string_view(kOfxHostNativeOriginBottomLeft));
+static_assert(string_view("kOfxImageEffectHostPropNativeOriginTopLeft") == string_view(kOfxHostNativeOriginTopLeft));
+static_assert(string_view("kOfxImageEffectHostPropNativeOriginCenter") == string_view(kOfxHostNativeOriginCenter));
+static_assert(string_view("OfxImageEffectRenderUnsafe") == string_view(kOfxImageEffectRenderUnsafe));
+static_assert(string_view("OfxImageEffectRenderInstanceSafe") == string_view(kOfxImageEffectRenderInstanceSafe));
+static_assert(string_view("OfxImageEffectRenderFullySafe") == string_view(kOfxImageEffectRenderFullySafe));
+static_assert(string_view("OfxImageEffectColourManagementNone") == string_view(kOfxImageEffectColourManagementNone));
+static_assert(string_view("OfxImageEffectColourManagementBasic") == string_view(kOfxImageEffectColourManagementBasic));
+static_assert(string_view("OfxImageEffectColourManagementCore") == string_view(kOfxImageEffectColourManagementCore));
+static_assert(string_view("OfxImageEffectColourManagementFull") == string_view(kOfxImageEffectColourManagementFull));
+static_assert(string_view("OfxImageEffectColourManagementOCIO") == string_view(kOfxImageEffectColourManagementOCIO));
+static_assert(string_view("OfxImageComponentNone") == string_view(kOfxImageComponentNone));
+static_assert(string_view("OfxImageComponentRGBA") == string_view(kOfxImageComponentRGBA));
+static_assert(string_view("OfxImageComponentRGB") == string_view(kOfxImageComponentRGB));
+static_assert(string_view("OfxImageComponentAlpha") == string_view(kOfxImageComponentAlpha));
+static_assert(string_view("OfxImageEffectContextGenerator") == string_view(kOfxImageEffectContextGenerator));
+static_assert(string_view("OfxImageEffectContextFilter") == string_view(kOfxImageEffectContextFilter));
+static_assert(string_view("OfxImageEffectContextTransition") == string_view(kOfxImageEffectContextTransition));
+static_assert(string_view("OfxImageEffectContextPaint") == string_view(kOfxImageEffectContextPaint));
+static_assert(string_view("OfxImageEffectContextGeneral") == string_view(kOfxImageEffectContextGeneral));
+static_assert(string_view("OfxImageEffectContextRetimer") == string_view(kOfxImageEffectContextRetimer));
+static_assert(string_view("OfxFieldNone") == string_view(kOfxImageFieldNone));
+static_assert(string_view("OfxFieldBoth") == string_view(kOfxImageFieldBoth));
+static_assert(string_view("OfxFieldLower") == string_view(kOfxImageFieldLower));
+static_assert(string_view("OfxFieldUpper") == string_view(kOfxImageFieldUpper));
+static_assert(string_view("OfxBitDepthNone") == string_view(kOfxBitDepthNone));
+static_assert(string_view("OfxBitDepthByte") == string_view(kOfxBitDepthByte));
+static_assert(string_view("OfxBitDepthShort") == string_view(kOfxBitDepthShort));
+static_assert(string_view("OfxBitDepthHalf") == string_view(kOfxBitDepthHalf));
+static_assert(string_view("OfxBitDepthFloat") == string_view(kOfxBitDepthFloat));
+static_assert(string_view("OfxImageOpaque") == string_view(kOfxImageOpaque));
+static_assert(string_view("OfxImageAlphaPremultiplied") == string_view(kOfxImagePreMultiplied));
+static_assert(string_view("OfxImageAlphaUnPremultiplied") == string_view(kOfxImageUnPreMultiplied));
+static_assert(string_view("OfxImageComponentNone") == string_view(kOfxImageComponentNone));
+static_assert(string_view("OfxImageComponentRGBA") == string_view(kOfxImageComponentRGBA));
+static_assert(string_view("OfxImageComponentRGB") == string_view(kOfxImageComponentRGB));
+static_assert(string_view("OfxImageComponentAlpha") == string_view(kOfxImageComponentAlpha));
+static_assert(string_view("OfxImageEffectContextGenerator") == string_view(kOfxImageEffectContextGenerator));
+static_assert(string_view("OfxImageEffectContextFilter") == string_view(kOfxImageEffectContextFilter));
+static_assert(string_view("OfxImageEffectContextTransition") == string_view(kOfxImageEffectContextTransition));
+static_assert(string_view("OfxImageEffectContextPaint") == string_view(kOfxImageEffectContextPaint));
+static_assert(string_view("OfxImageEffectContextGeneral") == string_view(kOfxImageEffectContextGeneral));
+static_assert(string_view("OfxImageEffectContextRetimer") == string_view(kOfxImageEffectContextRetimer));
+static_assert(string_view("OfxBitDepthNone") == string_view(kOfxBitDepthNone));
+static_assert(string_view("OfxBitDepthByte") == string_view(kOfxBitDepthByte));
+static_assert(string_view("OfxBitDepthShort") == string_view(kOfxBitDepthShort));
+static_assert(string_view("OfxBitDepthHalf") == string_view(kOfxBitDepthHalf));
+static_assert(string_view("OfxBitDepthFloat") == string_view(kOfxBitDepthFloat));
+static_assert(string_view("OfxFieldNone") == string_view(kOfxImageFieldNone));
+static_assert(string_view("OfxFieldBoth") == string_view(kOfxImageFieldBoth));
+static_assert(string_view("OfxFieldLower") == string_view(kOfxImageFieldLower));
+static_assert(string_view("OfxFieldUpper") == string_view(kOfxImageFieldUpper));
+static_assert(string_view("OfxBitDepthNone") == string_view(kOfxBitDepthNone));
+static_assert(string_view("OfxBitDepthByte") == string_view(kOfxBitDepthByte));
+static_assert(string_view("OfxBitDepthShort") == string_view(kOfxBitDepthShort));
+static_assert(string_view("OfxBitDepthHalf") == string_view(kOfxBitDepthHalf));
+static_assert(string_view("OfxBitDepthFloat") == string_view(kOfxBitDepthFloat));
+static_assert(string_view("OfxParamInvalidateValueChange") == string_view(kOfxParamInvalidateValueChange));
+static_assert(string_view("OfxParamInvalidateValueChangeToEnd") == string_view(kOfxParamInvalidateValueChangeToEnd));
+static_assert(string_view("OfxParamInvalidateAll") == string_view(kOfxParamInvalidateAll));
+static_assert(string_view("OfxParamCoordinatesCanonical") == string_view(kOfxParamCoordinatesCanonical));
+static_assert(string_view("OfxParamCoordinatesNormalised") == string_view(kOfxParamCoordinatesNormalised));
+static_assert(string_view("OfxParamDoubleTypePlain") == string_view(kOfxParamDoubleTypePlain));
+static_assert(string_view("OfxParamDoubleTypeAngle") == string_view(kOfxParamDoubleTypeAngle));
+static_assert(string_view("OfxParamDoubleTypeScale") == string_view(kOfxParamDoubleTypeScale));
+static_assert(string_view("OfxParamDoubleTypeTime") == string_view(kOfxParamDoubleTypeTime));
+static_assert(string_view("OfxParamDoubleTypeAbsoluteTime") == string_view(kOfxParamDoubleTypeAbsoluteTime));
+static_assert(string_view("OfxParamDoubleTypeX") == string_view(kOfxParamDoubleTypeX));
+static_assert(string_view("OfxParamDoubleTypeXAbsolute") == string_view(kOfxParamDoubleTypeXAbsolute));
+static_assert(string_view("OfxParamDoubleTypeY") == string_view(kOfxParamDoubleTypeY));
+static_assert(string_view("OfxParamDoubleTypeYAbsolute") == string_view(kOfxParamDoubleTypeYAbsolute));
+static_assert(string_view("OfxParamDoubleTypeXY") == string_view(kOfxParamDoubleTypeXY));
+static_assert(string_view("OfxParamDoubleTypeXYAbsolute") == string_view(kOfxParamDoubleTypeXYAbsolute));
+static_assert(string_view("OfxParamStringIsSingleLine") == string_view(kOfxParamStringIsSingleLine));
+static_assert(string_view("OfxParamStringIsMultiLine") == string_view(kOfxParamStringIsMultiLine));
+static_assert(string_view("OfxParamStringIsFilePath") == string_view(kOfxParamStringIsFilePath));
+static_assert(string_view("OfxParamStringIsDirectoryPath") == string_view(kOfxParamStringIsDirectoryPath));
+static_assert(string_view("OfxParamStringIsLabel") == string_view(kOfxParamStringIsLabel));
+static_assert(string_view("OfxParamStringIsRichTextFormat") == string_view(kOfxParamStringIsRichTextFormat));
+static_assert(string_view("OfxChangeUserEdited") == string_view(kOfxChangeUserEdited));
+static_assert(string_view("OfxChangePluginEdited") == string_view(kOfxChangePluginEdited));
+static_assert(string_view("OfxChangeTime") == string_view(kOfxChangeTime));
 } // namespace assertions
 } // namespace openfx

--- a/scripts/gen-props.py
+++ b/scripts/gen-props.py
@@ -56,12 +56,6 @@ def getPropertiesFromFile(path):
             # ignore these
             nonProperties = (
                 "kOfxPropertySuite",
-                # prop values, not props
-                "kOfxImageEffectPropColourManagementNone",
-                "kOfxImageEffectPropColourManagementBasic",
-                "kOfxImageEffectPropColourManagementCore",
-                "kOfxImageEffectPropColourManagementFull",
-                "kOfxImageEffectPropColourManagementOCIO",
             )
             if splits[1] in nonProperties:
                 continue
@@ -92,6 +86,48 @@ def getPropertiesFromDir(dir):
                 file_path = os.path.join(root, file)
                 props |= getPropertiesFromFile(file_path)
     return list(props)
+
+
+def get_string_defines(dir):
+    """Collect every `#define kName "value"` macro and its string value.
+
+    Returns {value: cname}, mapping each string literal to the C macro that
+    defines it. Used to resolve enum @propdef values back to the #define they
+    name, so we can emit static_asserts and catch typo'd value names. If two
+    macros share a value the lexically-first cname wins (either asserts the
+    same string, so the choice is immaterial).
+    """
+    extensions = {".c", ".h", ".cxx", ".hxx", ".cpp", ".hpp"}
+    value_to_cname = {}
+    pattern = re.compile(r'#define\s+(k\w+)\s+"([^"]+)"')
+    for root, _dirs, files in os.walk(dir):
+        for file in sorted(files):
+            if os.path.splitext(file)[1] not in extensions:
+                continue
+            with open(os.path.join(root, file)) as f:
+                for m in pattern.finditer(f.read()):
+                    cname, value = m.group(1), m.group(2)
+                    if value not in value_to_cname or cname < value_to_cname[value]:
+                        value_to_cname[value] = cname
+    return value_to_cname
+
+
+def enum_value_cname(value, value_to_cname):
+    """Resolve an enum @propdef value to the #define that names it.
+
+    Returns the macro cname, or None if the value is an intentional literal
+    (e.g. "true"/"false"/"needed") with no backing #define. Raises ValueError
+    if the value looks like an OFX constant but has no matching #define, which
+    is the typo class of bug this guards against (issue #247).
+    """
+    if value in value_to_cname:
+        return value_to_cname[value]
+    if value.startswith("Ofx") or value.startswith("kOfx"):
+        raise ValueError(
+            f"enum value '{value}' has no matching #define; "
+            f"the @propdef value must equal a macro's string literal"
+        )
+    return None  # bare literal value, not a #define
 
 
 def get_def(name: str, defs):
@@ -327,7 +363,7 @@ def check_props_used_by_set(props_by_set, props_by_action, props_metadata):
     return errs
 
 
-def gen_props_metadata(props_metadata, outfile_path: Path):
+def gen_props_metadata(props_metadata, value_to_cname, outfile_path: Path):
     """Generate a header file with metadata for each prop"""
     with open(outfile_path, "w") as outfile:
         outfile.write(generated_source_header)
@@ -513,6 +549,21 @@ struct PropTraits<PropId::id> { \\
             outfile.write(
                 f'static_assert(string_view("{p}") == string_view({cname}));\n'
             )
+
+        # Also assert each enum value equals the #define it names, so a typo'd
+        # @propdef value (issue #247) fails to compile. enum_value_cname raises
+        # here if a value looks like an OFX constant but names no macro.
+        outfile.write("\n// ... and enum values vs their #defines\n")
+        for p in sorted(props_metadata):
+            md = props_metadata[p]
+            if md["type"] != "enum":
+                continue
+            for v in md["values"]:
+                cname = enum_value_cname(v, value_to_cname)
+                if cname:
+                    outfile.write(
+                        f'static_assert(string_view("{v}") == string_view({cname}));\n'
+                    )
 
         outfile.write("} // namespace assertions\n")
         outfile.write("} // namespace openfx\n")
@@ -1132,6 +1183,7 @@ def main(args):
     props_by_set = expand_set_props(get_propsets_from_headers(include_dir))
     props_by_action = get_actions_from_headers(include_dir)
     props_metadata = get_properties_from_headers(include_dir)
+    value_to_cname = get_string_defines(include_dir)
 
     # Convert action argument property sets to the same format as regular property sets
     action_propsets = actions_to_propsets(props_by_action)
@@ -1165,7 +1217,7 @@ def main(args):
 
     if args.verbose:
         print(f"=== Generating {args.props_metadata}")
-    gen_props_metadata(props_metadata, dest_path / args.props_metadata)
+    gen_props_metadata(props_metadata, value_to_cname, dest_path / args.props_metadata)
 
     if args.verbose:
         print(f"=== Generating props by set header {args.props_by_set}")


### PR DESCRIPTION
Fixes #247.

## Problem

Enum properties declare their valid values in `@propdef … values:`. By convention each value is the **string literal** its value-`#define` expands to. Four clusters violated that, so the generated `openfx-cpp` metadata (`ofxPropsMetadata.h` enum arrays) and the generated property docs advertised valid-value strings that **no host or plugin actually uses** — anything validating a real value against the metadata would reject it.

The macro **string values are wire/ABI and must not change** (e.g. `kOfxImagePreMultiplied` has always been `"OfxImageAlphaPremultiplied"`). So this corrects only the metadata to match reality; no `#define` names or values are touched.

## What changed

| Property/cluster | was (wrong) | now (real macro string) |
|---|---|---|
| Field ×4¹ | `OfxImageFieldNone`, `…Lower`, … | `OfxFieldNone`, `OfxFieldLower`, … |
| `…PropPreMultiplication` | `OfxImagePreMultiplied`, `OfxImageUnPreMultiplied` | `OfxImageAlphaPremultiplied`, `OfxImageAlphaUnPremultiplied` |
| `…HostPropNativeOrigin` | `OfxImageEffectHostPropNativeOrigin{…}` | `kOfxImageEffectHostPropNativeOrigin{…}` (the literals really do start with `k`) |
| `…PropColourManagementStyle` | `OfxImageEffectPropColourManagement{…}` | `OfxImageEffectColourManagement{…}` (no "Prop") |

¹ `FieldOrder`, `PropField`, `FieldExtraction`, `FieldToRender`. The `true`/`false`/`needed` literal enums are correct and untouched.

## Regression guard

Following the codebase's existing pattern (generated `static_assert(string_view("Ofx…") == string_view(kOfx…))` for every property name), `gen-props.py` now also:

- emits a `static_assert` for **every enum value** (`value string == its #define`), so drift fails to compile; and
- **aborts generation** if an `Ofx`-prefixed enum value names no macro — the typo class that can't be expressed as an assert. Verified: reintroducing `OfxImagePreMultiplied` makes `gen-props.py` exit 1 with a clear message.

Also removed dead `nonProperties` entries in `gen-props.py` that listed misspelled (extra-"Prop") ColourManagement value macros which never existed; the real value macros contain no "Prop" so were never collected. Confirmed **byte-identical** output.

## Generated / regenerated

- `openfx-cpp/include/openfx/ofxPropsMetadata.h` — corrected enum arrays + new per-value asserts.
- `Documentation/.../ofxPropertiesReferenceGenerated.rst`, `ofxPropertySetsGenerated.rst` — corrected value lists. The doc regen also picks up `kOfxImageEffectPluginPropObsolete`, whose generated docs were already stale on `main` (incidental, unrelated to #247).

## Validation

- `gen-props.py` and `gen-props-doc.py` both run clean and are idempotent.
- Negative test: a reintroduced bad value aborts the generator (exit 1).
- No header `#define` names or string values changed → no ABI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)