### PR TITLE
Don't impose example-only conan deps (opengl/cimg/spdlog) on consumers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,7 +336,7 @@ jobs:
           MATRIX_BUILDTYPE: ${{ matrix.buildtype }}
         run: |
           [[ "$MATRIX_OPENGL" != false && "$MATRIX_OPENCL" = true ]] && USE_OPENCL="-o use_opencl=True"
-          conan install -s build_type=$MATRIX_BUILDTYPE -pr:b=default --build=missing . -c tools.cmake.cmaketoolchain:generator=Ninja $USE_OPENCL
+          conan install -s build_type=$MATRIX_BUILDTYPE -pr:b=default --build=missing . -c tools.cmake.cmaketoolchain:generator=Ninja -o build_examples=True $USE_OPENCL
 
       - name: Configure project with cmake
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,12 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_BINARY_DIR})
 
 # Conan packages
 find_package(EXPAT)
-find_package(opengl_system REQUIRED)
-find_package(cimg REQUIRED)
-find_package(spdlog REQUIRED)
+if(BUILD_EXAMPLE_PLUGINS)
+  # Used only by the example plugins, not by the OpenFX libraries.
+  find_package(opengl_system REQUIRED)
+  find_package(cimg REQUIRED)
+  find_package(spdlog REQUIRED)
+endif()
 
 # Macros
 include(OpenFX)

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,22 +26,28 @@ class openfx(ConanFile):
 	)
 
 	settings = "os", "arch", "compiler", "build_type"
-	options = {"use_opencl": [True, False]}
+	options = {
+		"build_examples": [True, False],
+		"use_opencl": [True, False],
+	}
 	default_options = {
 		"expat/*:shared": True,
-                "use_opencl": False,
-                "spdlog/*:header_only": True,
-                "fmt/*:header_only": True
+		"build_examples": False,
+		"use_opencl": False,
+		"spdlog/*:header_only": True,
+		"fmt/*:header_only": True
 	}
-	
+
 	def requirements(self):
-		if self.options.use_opencl: # for OpenCL examples
-			self.requires("opencl-icd-loader/2023.12.14")
-			self.requires("opencl-headers/2023.12.14")
-		self.requires("opengl/system") # for OpenGL examples
 		self.requires("expat/2.7.1") # for HostSupport
-		self.requires("cimg/3.3.2") # to draw text into images
-		self.requires("spdlog/1.13.0") # for logging
+		# Everything below is used only by the example plugins.
+		if self.options.build_examples:
+			self.requires("opengl/system")
+			self.requires("cimg/3.3.2") # to draw text into images
+			self.requires("spdlog/1.13.0") # for logging
+			if self.options.use_opencl:
+				self.requires("opencl-icd-loader/2023.12.14")
+				self.requires("opencl-headers/2023.12.14")
 
 	def layout(self):
 		cmake_layout(self)
@@ -51,6 +57,7 @@ class openfx(ConanFile):
 		deps.generate()
 
 		tc = CMakeToolchain(self)
+		tc.cache_variables["BUILD_EXAMPLE_PLUGINS"] = bool(self.options.build_examples)
 		tc.generate()
 
 	def build(self):
@@ -104,9 +111,15 @@ class openfx(ConanFile):
 		self.cpp_info.components["Api"].includedirs = ["include"]
 		self.cpp_info.components["HostSupport"].libs = [i for i in libs if "OfxHost" in i]
 		self.cpp_info.components["HostSupport"].includedirs = ["include/HostSupport"]
-		# spdlog is used by the example/host logging helpers (header-only here).
-		self.cpp_info.components["HostSupport"].requires = ["expat::expat", "spdlog::spdlog"]
+		self.cpp_info.components["HostSupport"].requires = ["Api", "expat::expat"]
 		self.cpp_info.components["Support"].libs = [i for i in libs if "OfxSupport" in i]
 		self.cpp_info.components["Support"].includedirs = ["include/Support", "include/Support/Plugins"]
-		# cimg is used by the support example plugins to draw text (header-only).
-		self.cpp_info.components["Support"].requires = ["opengl::opengl", "cimg::cimg"]
+		self.cpp_info.components["Support"].requires = ["Api"]
+		if self.options.build_examples:
+			# The packaged example plugins use these; consumers of the
+			# libraries alone (build_examples=False) need only expat.
+			self.cpp_info.components["Support"].requires += ["opengl::opengl", "cimg::cimg"]
+			self.cpp_info.components["HostSupport"].requires += ["spdlog::spdlog"]
+			if self.options.use_opencl:
+				self.cpp_info.components["Support"].requires += [
+					"opencl-icd-loader::opencl-icd-loader", "opencl-headers::opencl-headers"]


### PR DESCRIPTION
Follow-up to #246 / #238. The in-repo conan recipe required `opengl`, `cimg`, and `spdlog` for everyone and attached them to the `HostSupport`/`Support` components — but those are used only by the example plugins. Verified: no source file or packaged header outside `Examples/` and `Support/Plugins/*.cpp` references them.

- Consumers of the libraries now depend on **expat only**, matching the ConanCenter recipe's dependency set (this lets CCI drop the requirements half of its `disable-example-requirements` patch at the next release).
- New `build_examples` option (default `False`) gates the extra requirements and drives `BUILD_EXAMPLE_PLUGINS` via the toolchain.
- The top-level `find_package(opengl_system/cimg/spdlog)` calls are gated on `BUILD_EXAMPLE_PLUGINS`, so a library-only CMake build no longer needs them.
- CI passes `-o build_examples=True` so all examples still build and run in CI.

Tested locally (macOS, apple-clang 21): `conan create` both with and without `build_examples`; the default package contains only headers + libs and its consumer graph shows just `expat/2.7.1`, while the examples variant builds all `.ofx` plugins and pulls cimg/spdlog/opengl as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)