### PR TITLE
Fix stale 1.4.0 version: bump to 1.5.1, derive conan version from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.16.0)
 if(OFX_SUPPORTS_CUDARENDER AND NOT APPLE)
   project(
     openfx
-    VERSION 1.4.0
+    VERSION 1.5.1
     LANGUAGES CXX CUDA)
 else()
   project(
     openfx
-    VERSION 1.4.0
+    VERSION 1.5.1
     LANGUAGES CXX) # no CUDA
 endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,13 +1,13 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, collect_libs
+from conan.tools.files import copy, collect_libs, load
 import os.path
+import re
 
 required_conan_version = ">=1.59.0"
 
 class openfx(ConanFile):
 	name = "openfx"
-	version = "1.4.0"
 	license = "BSD-3-Clause"
 	url = "https://github.com/AcademySoftwareFoundation/openfx"
 	description = "OpenFX image processing plug-in standard"
@@ -24,6 +24,11 @@ class openfx(ConanFile):
 		"README.md",
 		"install.md"
 	)
+
+	def set_version(self):
+		# Single source of truth: the project() VERSION in CMakeLists.txt.
+		cmakelists = load(self, os.path.join(self.recipe_folder, "CMakeLists.txt"))
+		self.version = re.search(r"^\s*VERSION\s+([0-9.]+)", cmakelists, re.MULTILINE).group(1)
 
 	settings = "os", "arch", "compiler", "build_type"
 	options = {


### PR DESCRIPTION
Both the CMake project() version and the conan recipe still said 1.4.0, two releases behind. Bump CMakeLists.txt to 1.5.1 and make the conan recipe read its version from the project() VERSION via set_version(), so future release bumps happen in one place.